### PR TITLE
Fixed bug in test/test-multimodal.cpp

### DIFF
--- a/test/multimodal/networks/README.txt
+++ b/test/multimodal/networks/README.txt
@@ -1,0 +1,1 @@
+When test-multimodal is run, this folder is temporarily populated with sample multimodal networks used to exercise TMMNet::GetSubgraphByCrossNetMetapaths. When the test is complete, the files are deleted.


### PR DESCRIPTION
Previous pull request did not include test/multimodal/networks folder, which caused the multimodal.ReconstituteNetworks test to fail. 

This commit adds a dummy README.txt in test/multimodal/networks, which should allow the test to create the necessary files and finish properly.