### PR TITLE
C++11 and range-loop support

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -22,7 +22,7 @@ UNAME := $(shell uname)
 ifeq ($(UNAME), Linux)
   # Linux flags
   CC = g++
-  CXXFLAGS += -std=c++11 -Wall
+  CXXFLAGS += -std=c++0x -Wall
   CXXFLAGS += -O3 -DNDEBUG -fopenmp
   # turn on for crash debugging, get symbols with <prog> 2>&1 | c++filt
   #CXXFLAGS += -g -rdynamic

--- a/Makefile.config
+++ b/Makefile.config
@@ -22,20 +22,20 @@ UNAME := $(shell uname)
 ifeq ($(UNAME), Linux)
   # Linux flags
   CC = g++
-  CXXFLAGS += -std=c++98 -Wall
-  CXXFLAGS += -O3 -DNDEBUG -fopenmp 
+  CXXFLAGS += -std=c++11 -Wall
+  #CXXFLAGS += -O3 -DNDEBUG -fopenmp
   # turn on for crash debugging, get symbols with <prog> 2>&1 | c++filt
-  #CXXFLAGS += -g -rdynamic 
-  #CXXFLAGS += -ggdb
+  CXXFLAGS += -g -rdynamic
+  CXXFLAGS += -ggdb
   # turn on for OpenMP
-  CXXOPENMP = 
+  CXXOPENMP =
   LDFLAGS +=
   LIBS += -lrt
 
 else ifeq ($(UNAME), Darwin)
   # OS X flags
   CC = g++
-  CXXFLAGS += -std=c++98 -Wall -Wno-unknown-pragmas
+  CXXFLAGS += -std=c++11 -Wall -Wno-unknown-pragmas
   CXXFLAGS += -O3 -DNDEBUG
   CLANG := $(shell g++ -v 2>&1 | grep clang | cut -d " " -f 2)
   ifneq ($(CLANG), LLVM)

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -44,6 +44,7 @@ MakeAll:
 	$(MAKE) -C rolx
 	$(MAKE) -C temporalmotifs
 	$(MAKE) -C testgraph
+	$(MAKE) -C iterators
 
 clean:
 	$(MAKE) clean -C agmgen
@@ -84,4 +85,5 @@ clean:
 	$(MAKE) clean -C rolx
 	$(MAKE) clean -C temporalmotifs
 	$(MAKE) clean -C testgraph
+	$(MAKE) clean -C iterators
 	rm -rf Debug Release ipch

--- a/examples/bigclam/bigclam.cpp
+++ b/examples/bigclam/bigclam.cpp
@@ -28,7 +28,7 @@ int main(int argc, char* argv[]) {
 #endif
   PUNGraph G;
   TIntStrH NIDNameH;
-  if (InFNm.IsSuffix(".ungraph")) {
+  if (InFNm.EndsWith(".ungraph")) {
     TFIn GFIn(InFNm);
     G = TUNGraph::Load(GFIn);
   } else if (LabelFNm.Len() > 0) {
@@ -43,11 +43,11 @@ int main(int argc, char* argv[]) {
   printf("Graph: %s Nodes %s Edges\n",
         TUInt64::GetStr(G->GetNodes()).CStr(),
         TUInt64::GetStr(G->GetEdges()).CStr());
-  
+
   TVec<TIntV> EstCmtyVV;
   TExeTm RunTm;
   TAGMFast RAGM(G, 10, 10);
-  
+
   if (OptComs == -1) {
     printf("finding number of communities\n");
     OptComs = RAGM.FindComsByCV(NumThreads, MaxComs, MinComs, DivComs, OutFPrx, StepAlpha, StepBeta);

--- a/examples/cesna/cesna.cpp
+++ b/examples/cesna/cesna.cpp
@@ -35,7 +35,7 @@ int main(int argc, char* argv[]) {
   TStrHash<TInt> NodeNameH;
   TVec<TFltV> Wck;
   TVec<TIntV> EstCmtyVV;
-  if (InFNm.IsSuffix(".ungraph")) {
+  if (InFNm.EndsWith(".ungraph")) {
     TFIn GFIn(InFNm);
     G = TUNGraph::Load(GFIn);
   } else {
@@ -73,7 +73,7 @@ int main(int argc, char* argv[]) {
 
   TExeTm RunTm;
   TCesna CS(G, NIDAttrH, 10, 10);
-  
+
   if (OptComs == -1) {
     printf("finding number of communities\n");
     OptComs = CS.FindComs(NumThreads, MaxComs, MinComs, DivComs, "", false, 0.1, StepAlpha, StepBeta);

--- a/examples/coda/coda.cpp
+++ b/examples/coda/coda.cpp
@@ -30,19 +30,19 @@ int main(int argc, char* argv[]) {
   TIntStrH NIDNameH;
   if (IsUndirected == 1) {
     PUNGraph UG;
-    if (InFNm.IsSuffix(".ungraph")) {
+    if (InFNm.EndsWith(".ungraph")) {
       TFIn GFIn(InFNm);
       UG = TUNGraph::Load(GFIn);
-      
+
     } else {
       UG = TAGMUtil::LoadEdgeListStr<PUNGraph>(InFNm, NIDNameH);
     }
     G = TSnap::ConvertGraph<PNGraph, PUNGraph>(UG);
   } else {
-    if (InFNm.IsSuffix(".ngraph")) {
+    if (InFNm.EndsWith(".ngraph")) {
       TFIn GFIn(InFNm);
       G = TNGraph::Load(GFIn);
-      
+
     } else {
       G = TAGMUtil::LoadEdgeListStr<PNGraph>(InFNm, NIDNameH);
     }
@@ -57,11 +57,11 @@ int main(int argc, char* argv[]) {
         TUInt64::GetStr(G->GetNodes()).CStr(),
         TUInt64::GetStr(G->GetEdges()).CStr());
 
-  
+
   TVec<TIntV> EstCmtyVVIn, EstCmtyVVOut;
   TExeTm RunTm;
   TCoda CD(G, 10, 10);
-  
+
   if (OptComs == -1) {
     printf("finding number of communities\n");
     OptComs = CD.FindComsByCV(NumThreads, MaxComs, MinComs, DivComs, OutFPrx, StepAlpha, StepBeta);

--- a/examples/iterators/Makefile
+++ b/examples/iterators/Makefile
@@ -1,0 +1,11 @@
+#
+#	Makefile for this SNAP example
+#	- modify Makefile.ex when creating a new SNAP example
+#
+#	implements:
+#		all (default), clean
+#
+
+include ../../Makefile.config
+include Makefile.ex
+include ../Makefile.exmain

--- a/examples/iterators/Makefile.ex
+++ b/examples/iterators/Makefile.ex
@@ -1,0 +1,7 @@
+#
+#	configuration variables for the example
+
+## Main application file
+MAIN = iterators
+DEPH =
+DEPCPP =

--- a/examples/iterators/iterators.cpp
+++ b/examples/iterators/iterators.cpp
@@ -134,5 +134,26 @@ int main(int argc, char* argv[]) {
     }
     printf("\n");
 
+    // table
+    Schema GradeS;
+    GradeS.Add(TPair<TStr,TAttrType>("Class", atStr));
+    GradeS.Add(TPair<TStr,TAttrType>("Area", atStr));
+    GradeS.Add(TPair<TStr,TAttrType>("Quarter", atStr));
+    GradeS.Add(TPair<TStr,TAttrType>("Grade 2011", atInt));
+    GradeS.Add(TPair<TStr,TAttrType>("Grade 2012", atInt));
+    GradeS.Add(TPair<TStr,TAttrType>("Grade 2013", atInt));
+    TInt64V RelevantCols;
+    RelevantCols.Add(0); RelevantCols.Add(1); RelevantCols.Add(2);
+    RelevantCols.Add(3); RelevantCols.Add(4); RelevantCols.Add(5);
+    TTableContext Context;
+    PTable P = TTable::LoadSS(GradeS, "../../test/table/grades.txt", &Context, RelevantCols);
+    // we can iterate over the rows
+    for (auto RI : P->GetRI()) {
+        printf("%s: %s %s %s %s %s %s\n", ToCStr(RI.GetRowIdx()), RI.GetStrAttr("Class").CStr(),
+            RI.GetStrAttr("Area").CStr(), RI.GetStrAttr("Quarter").CStr(),
+            ToCStr(RI.GetIntAttr("Grade 2011")), ToCStr(RI.GetIntAttr("Grade 2011")),
+            ToCStr(RI.GetIntAttr("Grade 2011")));
+    }
+
     return 0;
 }

--- a/examples/iterators/iterators.cpp
+++ b/examples/iterators/iterators.cpp
@@ -1,0 +1,46 @@
+#include "stdafx.h"
+
+int main(int argc, char* argv[]) {
+    printf("Testing iterators:\n");
+
+    // vectors
+    TIntV IntV = TIntV::GetV(1,2,3,4,5);
+    // we can iterate over vector and print out values
+    for (const int Val : IntV) {
+        printf("%d ", Val);
+    }
+    printf("\n");
+    // we can access values by reference and modify them
+    for (TInt& Val : IntV) {
+        Val = Val * Val;
+    }
+    // print out updated vector
+    for (const int Val : IntV) {
+        printf("%d ", Val);
+    }
+    printf("\n");
+
+    // hash tables
+    TIntH IntH;
+    for (int i = 0; i < 5; i++) {
+        IntH.AddDat(i, i*i);
+    }
+    // we can iterate and print out keys and dats
+    for (const auto& KeyDat : IntH) {
+        printf("(%d -> %d) ", KeyDat.Key.Val, KeyDat.Dat.Val);
+    }
+    printf("\n");
+    // we can access dats by reference and modify them
+    for (auto& KeyDat : IntH) {
+        KeyDat.Dat = KeyDat.Dat * KeyDat.Key;
+    }
+    // print out updated map
+    for (const auto& KeyDat : IntH) {
+        printf("(%d -> %d) ", KeyDat.Key.Val, KeyDat.Dat.Val);
+    }
+    printf("\n");
+
+    //
+
+    return 0;
+}

--- a/examples/iterators/iterators.cpp
+++ b/examples/iterators/iterators.cpp
@@ -40,7 +40,13 @@ int main(int argc, char* argv[]) {
     }
     printf("\n");
 
-    //
+    // has set
+    TIntSet IntSet = TIntSet(TIntV::GetV(1,2,3,4,5));
+    for (const auto& Key : IntSet) {
+        printf("%d ", Key.Val);
+    }
+    printf("\n");
+
 
     return 0;
 }

--- a/examples/iterators/iterators.cpp
+++ b/examples/iterators/iterators.cpp
@@ -40,13 +40,99 @@ int main(int argc, char* argv[]) {
     }
     printf("\n");
 
-    // has set
+    // hash set
     TIntSet IntSet = TIntSet(TIntV::GetV(1,2,3,4,5));
     for (const auto& Key : IntSet) {
         printf("%d ", Key.Val);
     }
     printf("\n");
 
+    // undirected graph iterator
+    PUNGraph UNGraph = TUNGraph::New();
+    for (int ni = 0; ni < 5; ni++) {
+        UNGraph->AddNode(ni);
+    }
+    UNGraph->AddEdge(0, 1);
+    UNGraph->AddEdge(0, 2);
+    UNGraph->AddEdge(0, 3);
+    UNGraph->AddEdge(3, 4);
+    // we can iterate over nodes
+    for (const auto& NI : UNGraph->GetNI()) {
+        printf("%s:%s ", ToCStr(NI.GetId()), ToCStr(NI.GetDeg()));
+    }
+    printf("\n");
+    for (auto& NI : UNGraph->GetNI()) {
+        printf("%s:%s ", ToCStr(NI.GetId()), ToCStr(NI.GetDeg()));
+        NI.SortNIdV();
+    }
+    printf("\n");
+    // we can also iterate over edges
+    for (const auto& EI : UNGraph->GetEI()) {
+        printf("(%s -> %s) ", ToCStr(EI.GetSrcNId()), ToCStr(EI.GetDstNId()));
+    }
+    printf("\n");
+
+    // directed graph iterator
+    PNGraph NGraph = TNGraph::New();
+    for (int ni = 0; ni < 5; ni++) {
+        NGraph->AddNode(ni);
+    }
+    NGraph->AddEdge(0, 1);
+    NGraph->AddEdge(1, 0);
+    NGraph->AddEdge(0, 2);
+    NGraph->AddEdge(0, 3);
+    NGraph->AddEdge(3, 4);
+    // we can iterate over nodes
+    for (const auto& NI : NGraph->GetNI()) {
+        printf("%s:%s ", ToCStr(NI.GetId()), ToCStr(NI.GetDeg()));
+    }
+    printf("\n");
+    // we can also iterate over edges
+    for (const auto& EI : NGraph->GetEI()) {
+        printf("(%s -> %s) ", ToCStr(EI.GetSrcNId()), ToCStr(EI.GetDstNId()));
+    }
+    printf("\n");
+
+    // directed multigraph iterator
+    PNEGraph NEGraph = TNEGraph::New();
+    for (int ni = 0; ni < 5; ni++) {
+        NEGraph->AddNode(ni);
+    }
+    NEGraph->AddEdge(0, 1);
+    NEGraph->AddEdge(0, 1);
+    NEGraph->AddEdge(0, 2);
+    NEGraph->AddEdge(0, 3);
+    NEGraph->AddEdge(3, 4);
+    // we can iterate over nodes
+    for (const auto& NI : NEGraph->GetNI()) {
+        printf("%s:%s ", ToCStr(NI.GetId()), ToCStr(NI.GetDeg()));
+    }
+    printf("\n");
+    // we can also iterate over edges
+    for (const auto& EI : NEGraph->GetEI()) {
+        printf("(%s -> %s) ", ToCStr(EI.GetSrcNId()), ToCStr(EI.GetDstNId()));
+    }
+    printf("\n");
+
+    // directed multigraph iterator
+    PNEANet NEANet = TNEANet::New();
+    for (int ni = 0; ni < 5; ni++) {
+        NEANet->AddNode(ni);
+    }
+    NEANet->AddEdge(0, 1, 123);
+    NEANet->AddEdge(0, 2, 234);
+    NEANet->AddEdge(0, 3, 345);
+    NEANet->AddEdge(3, 4, 456);
+    // we can iterate over nodes
+    for (const auto& NI : NEANet->GetNI()) {
+        printf("%s:%s ", ToCStr(NI.GetId()), ToCStr(NI.GetDeg()));
+    }
+    printf("\n");
+    // we can also iterate over edges
+    for (const auto& EI : NEANet->GetEI()) {
+        printf("(%s: %s -> %s) ", ToCStr(EI.GetId()), ToCStr(EI.GetSrcNId()), ToCStr(EI.GetDstNId()));
+    }
+    printf("\n");
 
     return 0;
 }

--- a/examples/iterators/stdafx.cpp
+++ b/examples/iterators/stdafx.cpp
@@ -1,0 +1,8 @@
+// stdafx.cpp : source file that includes just the standard includes
+// KronFit.pch will be the pre-compiled header
+// stdafx.obj will contain the pre-compiled type information
+
+#include "stdafx.h"
+
+// TODO: reference any additional headers you need in STDAFX.H
+// and not in this file

--- a/examples/iterators/stdafx.h
+++ b/examples/iterators/stdafx.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "Snap.h"

--- a/examples/knnjaccardsim/knnjaccardsim.cpp
+++ b/examples/knnjaccardsim/knnjaccardsim.cpp
@@ -36,4 +36,3 @@ int main(int argc,char* argv[]) {
   #endif
   return 0;
 }
-

--- a/examples/mkdatasets/mkdatasets.cpp
+++ b/examples/mkdatasets/mkdatasets.cpp
@@ -30,7 +30,7 @@ void PrintGraphStat(const PNGraph& G) {
   printf("90-percentile effective diameter\t%.2g\n", EffDiam);
 }
 
-template<class PGraph> 
+template<class PGraph>
 void PrintGraphStatTable(const PGraph& G, TStr OutFNm, TStr Desc="") {
   TFltPr64V DegCCfV;
   int64 ClosedTriads, OpenTriads;
@@ -231,7 +231,7 @@ void MakeSlashdotSignNet(const TStr InFNm, TStr OutFNm, TStr Desc, THashSet<TChA
     else if (strcmp(WrdV[1], "foes")==0) { Sign = -1; } else { Fail; }
     const int SrcNId = NIdSet.AddKey(WrdV[0]);
     if (! Net->IsNode(SrcNId)) {
-      Net->AddNode(SrcNId); }   
+      Net->AddNode(SrcNId); }
     for (int e = 2; e < WrdV.Len(); e++) {
       const int DstNId = NIdSet.AddKey(WrdV[e]);
       i ++ ;
@@ -240,19 +240,19 @@ void MakeSlashdotSignNet(const TStr InFNm, TStr OutFNm, TStr Desc, THashSet<TChA
           Net->AddNode(DstNId);
         Net->AddEdge(SrcNId, DstNId, Sign);
       }
-    }  
-  }  
-  TSnap::PrintInfo(Net, "Slashdot (" + TInt::GetStr(i) + ")");  
+    }
+  }
+  TSnap::PrintInfo(Net, "Slashdot (" + TInt::GetStr(i) + ")");
 
   // copied from gio.h - line 111
   FILE *F = fopen(OutFNm.CStr(), "wt");
   fprintf(F, "# Directed graph: %s\n", OutFNm.CStr());
-  if (! Desc.Empty()) 
+  if (! Desc.Empty())
     fprintf(F, "# %s\n", (Desc).CStr());
     fprintf(F, "# Nodes: %s Edges: %s\n",
         TUInt64::GetStr(Net->GetNodes()).CStr(),
         TUInt64::GetStr(Net->GetEdges()).CStr());
-    fprintf(F, "# UserId\tGroupId\tSign\n"); 
+    fprintf(F, "# UserId\tGroupId\tSign\n");
   for (TNodeEDatNet<TInt,TInt>::TEdgeI ei = Net->BegEI(); ei < Net->EndEI(); ei++) {
       fprintf(F, "%s\t%s\t%d\n",
           TInt64::GetStr(ei.GetSrcNId()).CStr(),
@@ -260,7 +260,7 @@ void MakeSlashdotSignNet(const TStr InFNm, TStr OutFNm, TStr Desc, THashSet<TChA
           ei()());
   }
   fclose(F);
-  
+
   PrintGraphStatTable(Net, OutFNm, Desc);
 }
 
@@ -274,18 +274,18 @@ void MakeSlasdotSignNets(){
 void MakeLJNets(TStr InFNm, TStr OutFNm, TStr Desc){
   TStrHash<TInt> StrSet(Mega(1), true);
   for (int i = 1; i < 13; i++){
-    TStr tmp = "";  
-      
+    TStr tmp = "";
+
     if (i < 10)
-      tmp = InFNm + "ljgraph.0" + TInt::GetStr(i);  
+      tmp = InFNm + "ljgraph.0" + TInt::GetStr(i);
     else
-      tmp = InFNm + "ljgraph." + TInt::GetStr(i);  
-  
-    printf("%s\n",tmp());
+      tmp = InFNm + "ljgraph." + TInt::GetStr(i);
+
+    printf("%s\n",tmp.CStr());
 
     TSsParser Ss(tmp, ssfTabSep);
     PNGraph Graph = TNGraph::New();
-      
+
     while (Ss.Next()) {
       const int SrcNId = StrSet.AddKey(Ss[0]);
       if (! Graph->IsNode(SrcNId)) { Graph->AddNode(SrcNId); }
@@ -303,7 +303,7 @@ void MakeLJNets(TStr InFNm, TStr OutFNm, TStr Desc){
       OutFNm = "soc-lj-friends.0"+TInt::GetStr(i);
     else
       OutFNm = "soc-lj-friends."+TInt::GetStr(i);
-  
+
     PrintGraphStatTable(Graph, OutFNm, Desc);
   }
 }
@@ -311,24 +311,24 @@ void MakeLJNets(TStr InFNm, TStr OutFNm, TStr Desc){
 void MakeLJGroupsNets(const TStr InFNm, TStr OutFNm, TStr Desc){
   TStrHash<TInt> StrSetU(Mega(1), true);
   TStrHash<TInt> StrSetG(Mega(1), true);
-  
+
   for (int i = 1; i < 13; i++){
-    TStr tmp = "";  
-      
+    TStr tmp = "";
+
     if (i < 10)
-      tmp = InFNm + "ljgraph.0" + TInt::GetStr(i);  
+      tmp = InFNm + "ljgraph.0" + TInt::GetStr(i);
     else
-      tmp = InFNm + "ljgraph." + TInt::GetStr(i);  
-  
-    printf("%s\n",tmp());
+      tmp = InFNm + "ljgraph." + TInt::GetStr(i);
+
+    printf("%s\n",tmp.CStr());
 
     TSsParser Ss(tmp, ssfTabSep);
     PNGraph Graph = TNGraph::New();
-      
+
     while (Ss.Next()) {
       const int SrcNId = StrSetU.AddKey(Ss[0]);
-      if (! Graph->IsNode(SrcNId)) 
-         Graph->AddNode(SrcNId); 
+      if (! Graph->IsNode(SrcNId))
+         Graph->AddNode(SrcNId);
       for (int dst = 2; dst < Ss.Len(); dst++) {
         TStr ls,rs;
           ((TStr)Ss[dst]).SplitOnCh(ls,' ',rs);
@@ -343,44 +343,44 @@ void MakeLJGroupsNets(const TStr InFNm, TStr OutFNm, TStr Desc){
       OutFNm = "soc-lj-friends.0"+TInt::GetStr(i);
     else
       OutFNm = "soc-lj-friends."+TInt::GetStr(i);
-  
+
   //  PrintGraphStatTable(Graph, OutFNm, Desc);
   }
-  
+
   for (int i = 5; i < 14; i++){
-    TStr tmp = "";       
-    
-    tmp = InFNm + "ljcomm." + TInt::GetStr(i);  
-    printf("%s\n",tmp());
-    
+    TStr tmp = "";
+
+    tmp = InFNm + "ljcomm." + TInt::GetStr(i);
+    printf("%s\n",tmp.CStr());
+
     TSsParser Ss1(tmp, ssfTabSep);
-  
+
     PNGraph Graph1 = TNGraph::New();
     PNGraph Graph2 = TNGraph::New();
-  
-    TSsParser Ss(tmp, ssfTabSep);    
+
+    TSsParser Ss(tmp, ssfTabSep);
     while (Ss.Next()) {
       const int SrcNId = StrSetU.AddKey(Ss[0]);
       if (! Graph1->IsNode(SrcNId)) { Graph1->AddNode(SrcNId); }
       if (! Graph2->IsNode(SrcNId)) { Graph2->AddNode(SrcNId); }
-      
-      for (int dst = 2; dst < Ss.Len(); dst++) {   
+
+      for (int dst = 2; dst < Ss.Len(); dst++) {
         TStr ls,rs;
-        ((TStr)Ss[dst]).SplitOnCh(ls,' ',rs);            
+        ((TStr)Ss[dst]).SplitOnCh(ls,' ',rs);
         const int DstNId = StrSetG.AddKey(rs) + 10000000;
         if (! Graph1->IsNode(DstNId)) { Graph1->AddNode(DstNId); }
         if (! Graph2->IsNode(DstNId)) { Graph2->AddNode(DstNId); }
         if (ls == "<") // member
-          Graph1->AddEdge(SrcNId, DstNId);  
+          Graph1->AddEdge(SrcNId, DstNId);
         else if (ls == ">") // watching
-          Graph2->AddEdge(SrcNId, DstNId);      
+          Graph2->AddEdge(SrcNId, DstNId);
       }
     }
     OutFNm = "soc-lj-comm-";
     TStr s = "";
     if (i < 10)
       s = "0";
-    
+
     PrintGraphStatTable(Graph1, OutFNm+"members-" + s + TInt::GetStr(i), Desc+" communities - members");
     PrintGraphStatTable(Graph2, OutFNm+"watchers-"+ s + TInt::GetStr(i), Desc+" communities - watchers");
   }
@@ -391,9 +391,9 @@ void MakeSignEpinions() {
   //PSignNet Net = TSignNet::New();
   TPt<TNodeEDatNet<TInt, TInt> >  Net = TNodeEDatNet<TInt, TInt>::New();
   TStrHash<TInt> StrSet(Mega(1), true);
-      
+
   while (Ss.Next()) {
-    if ( ((TStr)Ss[0]).IsPrefix("#")  )
+    if ( ((TStr)Ss[0]).StartsWith("#")  )
       continue;
     const int SrcNId = StrSet.AddKey(Ss[0]);
     const int DstNId = StrSet.AddKey(Ss[1]);
@@ -402,7 +402,7 @@ void MakeSignEpinions() {
     const int Sign = ((TStr)Ss[2]).GetInt();
     Net->AddEdge(SrcNId, DstNId, Sign);
   }
-    
+
   //    PrintGraphStatTable(Graph, OutFNm, Desc);
   TStr OutFNm = "soc-sign-epinions-user-ratings";
   TStr Desc = "Epinions signed social network";
@@ -410,12 +410,12 @@ void MakeSignEpinions() {
   // copied from gio.h - line 111
   FILE *F = fopen(OutFNm.CStr(), "wt");
   fprintf(F, "# Directed graph: %s\n", OutFNm.CStr());
-  if (! Desc.Empty()) 
+  if (! Desc.Empty())
     fprintf(F, "# %s\n", (Desc).CStr());
   fprintf(F, "# Nodes: %s Edges: %s\n",
         TUInt64::GetStr(Net->GetNodes()).CStr(),
         TUInt64::GetStr(Net->GetEdges()).CStr());
-  fprintf(F, "# FromNodeId\tToNodeId\tSign\n"); 
+  fprintf(F, "# FromNodeId\tToNodeId\tSign\n");
   for (TNodeEDatNet<TInt,TInt>::TEdgeI ei = Net->BegEI(); ei < Net->EndEI(); ei++) {
       fprintf(F, "%s\t%s\t%d\n",
                     TInt64::GetStr(ei.GetSrcNId()).CStr(),
@@ -423,7 +423,7 @@ void MakeSignEpinions() {
                     ei()());
   }
   fclose(F);
-  
+
   PrintGraphStatTable(Net, OutFNm, Desc);
 }
 
@@ -442,15 +442,15 @@ void MakeASNets() {
 
 void MakeASSkitterNets() {
   { PUNGraph G = TSnap::LoadEdgeListStr<PUNGraph>("as-skitter.txt", 0, 1);
-  PrintGraphStatTable(G, "as-skitter", "Autonomous Systems (From traceroutes run daility in 2005 by skitter - http://www.caida.org/tools/measurement/skitter)"); 
+  PrintGraphStatTable(G, "as-skitter", "Autonomous Systems (From traceroutes run daility in 2005 by skitter - http://www.caida.org/tools/measurement/skitter)");
   }
 }
 
 void MakeASCaidaNets() {
   { PNGraph G = TSnap::LoadEdgeListStr<PNGraph>("/u/ana/data/AS-Caida/dataweb/as-caida20071105.txt", 0, 1);
-  PrintGraphStatTable(G , "as-caida20071105", "The CAIDA AS Relationships Dataset, from October 15 2007, http://www.caida.org/data/active/as-relationships/)"); } 
+  PrintGraphStatTable(G , "as-caida20071105", "The CAIDA AS Relationships Dataset, from October 15 2007, http://www.caida.org/data/active/as-relationships/)"); }
   { PNGraph G = TSnap::LoadEdgeListStr<PNGraph>("/u/ana/data/AS-Caida/dataweb/as-caida20070917.txt", 0, 1);
-  PrintGraphStatTable(G , "as-caida20070917", "The CAIDA AS Relationships Dataset, from October 15 2007, http://www.caida.org/data/active/as-relationships/)"); } 
+  PrintGraphStatTable(G , "as-caida20070917", "The CAIDA AS Relationships Dataset, from October 15 2007, http://www.caida.org/data/active/as-relationships/)"); }
 }
 
 
@@ -458,23 +458,23 @@ void MakeASOregonNets() {
   TStr files[18] = {"peer.oregon.010331","peer.oregon+.010331","peer.oregon.010407","peer.oregon+.010407","peer.oregon.010414","peer.oregon+.010414","peer.oregon.010421","peer.oregon+.010421","peer.oregon.010428","peer.oregon+.010428","peer.oregon.010505","peer.oregon+.010505","peer.oregon.010512","peer.oregon+.010512","peer.oregon.010519","peer.oregon+.010519","peer.oregon.010526","peer.oregon+.010526"};
   for (int i = 0; i < 18; i++){
     TStr tmp = ((TStr)"/u/ana/data/Oregon/") + files[i];
-    PUNGraph G = TSnap::LoadEdgeList<PUNGraph>(tmp(), 0, 1, ':');
+    PUNGraph G = TSnap::LoadEdgeList<PUNGraph>(tmp.CStr(), 0, 1, ':');
     if (files[i].GetCh(11) == '+'){
-      files[i].DelSubStr(0,4);    
+      files[i].DelSubStr(0,4);
       files[i].DelSubStr(6,7);
-      files[i].InsStr(6,"2_");    
-      PrintGraphStatTable(G , files[i](), "AS peering information inferred from Oregon route-views BGP data, from ");  
+      files[i].InsStr(6,"2_");
+      PrintGraphStatTable(G , files[i].CStr(), "AS peering information inferred from Oregon route-views BGP data, from ");
     }
     else{
-      files[i].DelSubStr(0,4);    
+      files[i].DelSubStr(0,4);
       files[i].DelSubStr(6,6);
       files[i].InsStr(6,"1_");
-      PrintGraphStatTable(G , files[i](), "AS peering information inferred from Oregon route-views BGP data, from ");  
+      PrintGraphStatTable(G , files[i].CStr(), "AS peering information inferred from Oregon route-views BGP data, from ");
     }
-  } 
-  
+  }
+
  /* { PUNGraph G = TSnap::LoadEdgeListStr<PUNGraph>("data/peer.all020515.txt", 0, 1);
-  PrintGraphStatTable(G , "peer.all020515", "AS peering information inferred from (1) Oregon route-views,(2) RIPE RIS BGP, (3) Looking glass data, and (4) Routing registry, all combined, May 15 2002"); } 
+  PrintGraphStatTable(G , "peer.all020515", "AS peering information inferred from (1) Oregon route-views,(2) RIPE RIS BGP, (3) Looking glass data, and (4) Routing registry, all combined, May 15 2002"); }
   { PUNGraph G = TSnap::LoadEdgeListStr<PUNGraph>("data/peer.ris020515.txt", 0, 1);
   PrintGraphStatTable(G , "peer.ris020515", "AS peering information inferred from RIPE RIS BGP data, May 15 2002"); } */
 }

--- a/examples/netstat/netstat.cpp
+++ b/examples/netstat/netstat.cpp
@@ -1,8 +1,8 @@
 #include "stdafx.h"
 
 template<class PGraph>
-void CreatePlots(const PGraph& Graph, TStr OutFNm, TStr Desc, 
-                 bool PlotDD, bool PlotCDD, bool PlotHop, bool PlotWcc, 
+void CreatePlots(const PGraph& Graph, TStr OutFNm, TStr Desc,
+                 bool PlotDD, bool PlotCDD, bool PlotHop, bool PlotWcc,
                  bool PlotScc, bool PlotSVal, bool PlotSVec, bool PlotClustCf) {
   printf("Creating plots...\n");
   const int SingularVals = Graph->GetNodes()/2 > 200 ? 200 : Graph->GetNodes()/2;
@@ -60,15 +60,15 @@ int main(int argc, char* argv[]) {
   PNGraph NGraph;
   PUNGraph UNGraph;
   // binary formats
-  if (InFNm.IsSuffix(".ngraph")) { 
+  if (InFNm.EndsWith(".ngraph")) {
     printf("directed graph (binary format)\n");
     TFIn FIn(InFNm);  NGraph = TNGraph::Load(FIn);
   } else
   if (InFNm.SearchStr(".ngraph.")!=-1 && TZipIn::IsZipFNm(InFNm)) {
     printf("directed graph (binary zipped format)\n");
     TZipIn ZipIn(InFNm);  NGraph = TNGraph::Load(ZipIn);
-  } else 
-  if (InFNm.IsSuffix(".ungraph")) { 
+  } else
+  if (InFNm.EndsWith(".ungraph")) {
     printf("undirected graph (binary format)\n");
     TFIn FIn(InFNm);  UNGraph = TUNGraph::Load(FIn);
   } else
@@ -85,14 +85,13 @@ int main(int argc, char* argv[]) {
     UNGraph = TSnap::LoadEdgeList<PUNGraph>(InFNm);
   }
   // create plots
-  if (! UNGraph.Empty()) { 
+  if (! UNGraph.Empty()) {
     TSnap::PrintInfo(UNGraph, InFNm, "", UNGraph->GetNodes()>Kilo(1));
     CreatePlots(UNGraph, OutFNm, Desc, PlotDD, PlotCDD, PlotHop, PlotWcc, PlotScc, PlotSVal, PlotSVec, PlotClustCf); }
-  if (! NGraph.Empty()) { 
+  if (! NGraph.Empty()) {
     TSnap::PrintInfo(NGraph, InFNm, "", NGraph->GetNodes()>Kilo(1));
     CreatePlots(NGraph, OutFNm, Desc, PlotDD, PlotCDD, PlotHop, PlotWcc, PlotScc, PlotSVal, PlotSVec, PlotClustCf); }
   Catch
   printf("\nrun time: %s (%s)\n", ExeTm.GetTmStr(), TSecTm::GetCurTm().GetTmStr().CStr());
   return 0;
 }
-

--- a/glib-core/bd.h
+++ b/glib-core/bd.h
@@ -572,7 +572,7 @@ public:
 // Swap
 template <class TRec>
 void Swap(TRec& Rec1, TRec& Rec2){
-  TRec Rec=Rec1; Rec1=Rec2; Rec2=Rec;
+  std::swap(Rec1, Rec2);
 }
 
 /////////////////////////////////////////////////

--- a/glib-core/dt.cpp
+++ b/glib-core/dt.cpp
@@ -662,17 +662,17 @@ const char TStr::EmptyStr = 0;
 TStr TStr::WrapCStr(char* _CStr) {
   TStr NewStr;
 
-  if (_CStr != nullptr && _CStr[0] == 0) {
+  if (_CStr != NULL && _CStr[0] == 0) {
     delete[] _CStr;
-  } else if (_CStr != nullptr) {
+  } else if (_CStr != NULL) {
     NewStr.Inner = _CStr;
   }
 
   return NewStr;
 }
 
-TStr::TStr(const char* _CStr): Inner(nullptr) {
-  if (_CStr == nullptr) { return; }
+TStr::TStr(const char* _CStr): Inner(NULL) {
+  if (_CStr == NULL) { return; }
 
   const int Len = (int)strlen(_CStr);
   if (Len > 0) {
@@ -681,33 +681,33 @@ TStr::TStr(const char* _CStr): Inner(nullptr) {
   }
 }
 
-TStr::TStr(const char& Ch): Inner(nullptr) {
+TStr::TStr(const char& Ch): Inner(NULL) {
     if (Ch != 0) {
         Inner = new char[2];
         Inner[0] = Ch; Inner[1] = 0;
     }
 }
 
-TStr::TStr(const TStr& Str): Inner(nullptr) {
+TStr::TStr(const TStr& Str): Inner(NULL) {
   if (!Str.Empty()) {
     Inner = Str.CloneCStr();
   }
 }
 
-TStr::TStr(TStr&& Str): Inner(nullptr) {
+TStr::TStr(TStr&& Str): Inner(NULL) {
     Inner = Str.Inner;
     // reset other
-    Str.Inner=nullptr;
+    Str.Inner=NULL;
 }
 
-TStr::TStr(const TChA& ChA): Inner(nullptr) {
+TStr::TStr(const TChA& ChA): Inner(NULL) {
     if (!ChA.Empty()) {
         Inner = new char[ChA.Len()+1];
         strcpy(Inner, ChA.CStr());
     }
 }
 
-TStr::TStr(const TMem& Mem): Inner(nullptr) {
+TStr::TStr(const TMem& Mem): Inner(NULL) {
     if (!Mem.Empty()) {
     const int Len = Mem.Len();
 
@@ -717,14 +717,14 @@ TStr::TStr(const TMem& Mem): Inner(nullptr) {
     }
 }
 
-TStr::TStr(const TSStr& SStr): Inner(nullptr) {
+TStr::TStr(const TSStr& SStr): Inner(NULL) {
   if (!SStr.Empty()) {
     Inner = new char[SStr.Len()+1];
     strcpy(Inner, SStr.CStr());
   }
 }
 
-TStr::TStr(const PSIn& SIn): Inner(nullptr) {
+TStr::TStr(const PSIn& SIn): Inner(NULL) {
   const int SInLen = SIn->Len();
   if (SInLen > 0) {
     Inner = new char[SInLen + 1];
@@ -733,7 +733,7 @@ TStr::TStr(const PSIn& SIn): Inner(nullptr) {
   }
 }
 
-TStr::TStr(TSIn& SIn, const bool& IsSmall): Inner(nullptr) {
+TStr::TStr(TSIn& SIn, const bool& IsSmall): Inner(NULL) {
   if (IsSmall) {
     if (SIn.PeekCh() == 0) {
             EAssert(SIn.GetCh() == 0);
@@ -749,9 +749,9 @@ TStr::TStr(TSIn& SIn, const bool& IsSmall): Inner(nullptr) {
     }
   }
     // delete buffer and replace with null in case it's ""
-    if (Inner != nullptr && Inner[0] == 0) {
+    if (Inner != NULL && Inner[0] == 0) {
     delete[] Inner;
-        Inner = nullptr;
+        Inner = NULL;
     }
 }
 
@@ -814,7 +814,7 @@ TStr& TStr::operator=(const char* CStr) {
 }
 
 bool TStr::operator==(const char* _CStr) const {
-  if (_CStr == nullptr) { return false; }
+  if (_CStr == NULL) { return false; }
   return (CStr() == _CStr) || (strcmp(CStr(), _CStr) == 0);
 }
 
@@ -850,14 +850,14 @@ char* TStr::CloneCStr() const {
 }
 
 bool TStr::Empty() const {
-   AssertR(Inner == nullptr || Inner[0] != 0, "TStr::Empty string is not nullptr. Fix immediately!");
-   return  Inner == nullptr;
+   AssertR(Inner == NULL || Inner[0] != 0, "TStr::Empty string is not NULL. Fix immediately!");
+   return  Inner == NULL;
 }
 
 void TStr::Clr() {
-  if (Inner != nullptr) {
+  if (Inner != NULL) {
     delete[] Inner;
-    Inner = nullptr;
+    Inner = NULL;
   }
 }
 
@@ -989,7 +989,7 @@ TStr TStr::GetSubStr(const int& BChN, const int& EChN) const {
   EAssertR(0 <= BChN && BChN <= EChN && EChN < StrLen, "TStr::GetSubStr index out of bounds");
   int Chs = EChN - BChN + 1;
   // initialize accordingly
-  char* Bf = nullptr;
+  char* Bf = NULL;
   if (Chs <= 0) {
     // create empty string
     return TStr();
@@ -1166,7 +1166,7 @@ void TStr::SplitOnCh(TStr& LStr, const char& SplitCh, TStr& RStr) const {
   const char* ChPtr = strchr(InnerPt, SplitCh);
 
   // if the character was not found than return this in the left string
-  if (ChPtr == nullptr) {
+  if (ChPtr == NULL) {
     LStr = *this;
     return;
   }
@@ -1186,7 +1186,7 @@ void TStr::SplitOnStr(TStr& LStr, const TStr& SplitStr, TStr& RStr) const {
 
   const char* MatchPt = strstr(InnerPt, SplitStr.CStr());
 
-  if (MatchPt == nullptr || SplitStr.Empty()) {
+  if (MatchPt == NULL || SplitStr.Empty()) {
     LStr = *this;
     return;
   }
@@ -1208,7 +1208,7 @@ void TStr::SplitOnLastCh(TStr& LStr, const char& SplitCh, TStr& RStr) const {
   const char* ChPtr = strrchr(InnerPt, SplitCh);
 
   // if the character was not found than return this in the right string
-  if (ChPtr == nullptr) {
+  if (ChPtr == NULL) {
     RStr = *this;
     return;
   }
@@ -1378,7 +1378,7 @@ int TStr::SearchStr(const TStr& Str, const int& BChN) const {
 
   const int NrBChN = BChN;
   const char* StrPt = strstr((const char*) CStr() + NrBChN, Str.CStr());
-  if (StrPt == nullptr) { return -1; }
+  if (StrPt == NULL) { return -1; }
   return int(StrPt - CStr());
 }
 
@@ -1452,7 +1452,7 @@ int TStr::ChangeStrAll(const TStr& SrcStr, const TStr& DstStr) {
   const char* NextHit;
 
   int NMatches = 0;
-  while ((NextHit = strstr(CurrPos, SrcCStr)) != nullptr) {
+  while ((NextHit = strstr(CurrPos, SrcCStr)) != NULL) {
     NMatches++;
     CurrPos = NextHit + SrcLen;
   }
@@ -1468,7 +1468,7 @@ int TStr::ChangeStrAll(const TStr& SrcStr, const TStr& DstStr) {
 
   // find next hit, copy everything between the current position and the hit,
   // then copy the dest string
-  while ((NextHit = strstr(InnerPt + i, SrcCStr)) != nullptr) {
+  while ((NextHit = strstr(InnerPt + i, SrcCStr)) != NULL) {
     SeqLen = (int)(NextHit - (InnerPt + i));
     // copy the chars in between the hits
     memcpy(ResStr + j, InnerPt + i, SeqLen);
@@ -1908,7 +1908,7 @@ TStr TStr::GetFNmStr(const TStr& Str, const bool& AlNumOnlyP){
 }
 
 TStr TStr::GetStr(const TStr& Str, const char* FmtStr){
-  if (FmtStr==nullptr){
+  if (FmtStr==NULL){
     return Str;
   } else {
     char Bf[1000];
@@ -1950,7 +1950,7 @@ TStr TStr::GetSpaceStr(const int& Spaces) {
 
 TStr operator+(const TStr& LStr, const char* RCStr) {
   const size_t LeftLen = LStr.Len();
-  const size_t RightLen = ((RCStr == nullptr) ? 0 : strlen(RCStr));
+  const size_t RightLen = ((RCStr == NULL) ? 0 : strlen(RCStr));
 
   // check if any of the strings are empty
   if (LeftLen == 0) { return TStr(RCStr); }

--- a/glib-core/dt.cpp
+++ b/glib-core/dt.cpp
@@ -291,7 +291,7 @@ void TMem::Del(const int& BChN, const int& EChN){
 void TMem::AddBf(const void* _Bf, const int& _BfL){
 	IAssert((_BfL>=0) && (_Bf != NULL));
   Reserve(Len() + _BfL, false);
-  memcpy(Bf + BfL, _Bf, _BfL);  
+  memcpy(Bf + BfL, _Bf, _BfL);
    BfL+=_BfL;
   //char* ChBf=(char*)Bf;
   //for (int BfC=0; BfC<BfL; BfC++){
@@ -449,7 +449,7 @@ TChA TChA::GetSubStr(const int& _BChN, const int& _EChN) const {
   int BChN=TInt::GetMx(_BChN, 0);
   int EChN=TInt::GetMn(_EChN, Len()-1);
   int Chs=EChN-BChN+1;
-  if (Chs<=0){return TStr::GetNullStr();}
+  if (Chs<=0){return TStr();}
   else if (Chs==Len()){return *this;}
   else {
     //char* Bf=new char[Chs+1]; strncpy(Bf, CStr()+BChN, Chs); Bf[Chs]=0;
@@ -656,85 +656,112 @@ bool TChAIn::GetNextLnBf(TChA& LnChA){
 }
 
 /////////////////////////////////////////////////
-// Ref-String
-bool TRStr::IsUc() const {
-  int StrLen=Len();
-  for (int ChN=0; ChN<StrLen; ChN++){
-    if (('a'<=Bf[ChN])&&(Bf[ChN]<='z')){return false;}}
-  return true;
-}
-
-void TRStr::ToUc(){
-  int StrLen=Len();
-  for (int ChN=0; ChN<StrLen; ChN++){
-    Bf[ChN]=(char)toupper(Bf[ChN]);}}
-
-bool TRStr::IsLc() const {
-  int StrLen=Len();
-  for (int ChN=0; ChN<StrLen; ChN++){
-    if (('A'<=Bf[ChN])&&(Bf[ChN]<='Z')){return false;}}
-  return true;
-}
-
-void TRStr::ToLc(){
-  int StrLen=Len();
-  for (int ChN=0; ChN<StrLen; ChN++){
-    Bf[ChN]=(char)tolower(Bf[ChN]);}
-}
-
-void TRStr::ToCap(){
-  int StrLen=Len();
-  if (StrLen>0){
-    Bf[0]=(char)toupper(Bf[0]);}
-  for (int ChN=1; ChN<StrLen; ChN++){
-    Bf[ChN]=(char)tolower(Bf[ChN]);}
-}
-
-void TRStr::ConvUsFromYuAscii(){
-  int StrLen=Len();
-  for (int ChN=0; ChN<StrLen; ChN++){
-    Bf[ChN]=TCh::GetUsFromYuAscii(Bf[ChN]);}
-}
-
-int TRStr::CmpI(const char* p, const char* r){
-  if (!p){return r ? (*r ? -1 : 0) : 0;}
-  if (!r){return (*p ? 1 : 0);}
-  while (*p && *r){
-    int i=int(toupper(*p++))-int(toupper(*r++));
-    if (i!=0){return i;}
-  }
-  return int(toupper(*p++))-int(toupper(*r++));
-}
-
-int TRStr::GetPrimHashCd() const {
-  return TStrHashF_DJB::GetPrimHashCd(Bf);
-}
-
-int TRStr::GetSecHashCd() const {
-  return TStrHashF_DJB::GetSecHashCd(Bf);
-}
-
-/////////////////////////////////////////////////
 // String
-TRStr* TStr::GetRStr(const char* CStr){
-  int CStrLen;
-  if (CStr==NULL){CStrLen=0;} else {CStrLen=int(strlen(CStr));}
-  if (CStrLen==0){return TRStr::GetNullRStr();}
-  // next lines are not multi-threading safe
-  //else if (CStrLen==1){return GetChStr(CStr[0]).RStr;}
-  //else if (CStrLen==2){return GetDChStr(CStr[0], CStr[1]).RStr;}
-  else {return new TRStr(CStr);}
+const char TStr::EmptyStr = 0;
+
+TStr TStr::WrapCStr(char* _CStr) {
+  TStr NewStr;
+
+  if (_CStr != nullptr && _CStr[0] == 0) {
+    delete[] _CStr;
+  } else if (_CStr != nullptr) {
+    NewStr.Inner = _CStr;
+  }
+
+  return NewStr;
 }
 
-void TStr::Optimize(){
-  char* CStr=RStr->CStr(); int CStrLen=int(strlen(CStr));
-  TRStr* NewRStr;
-  if (CStrLen==0){NewRStr=TRStr::GetNullRStr();}
-  // next lines are not multi-threading safe
-  //else if (CStrLen==1){NewRStr=GetChStr(CStr[0]).RStr;}
-  //else if (CStrLen==2){NewRStr=GetDChStr(CStr[0], CStr[1]).RStr;}
-  else {NewRStr=RStr;}
-  NewRStr->MkRef(); RStr->UnRef(); RStr=NewRStr;
+TStr::TStr(const char* _CStr): Inner(nullptr) {
+  if (_CStr == nullptr) { return; }
+
+  const int Len = (int)strlen(_CStr);
+  if (Len > 0) {
+    Inner = new char[Len+1];
+    strcpy(Inner, _CStr);
+  }
+}
+
+TStr::TStr(const char& Ch): Inner(nullptr) {
+    if (Ch != 0) {
+        Inner = new char[2];
+        Inner[0] = Ch; Inner[1] = 0;
+    }
+}
+
+TStr::TStr(const TStr& Str): Inner(nullptr) {
+  if (!Str.Empty()) {
+    Inner = Str.CloneCStr();
+  }
+}
+
+TStr::TStr(TStr&& Str): Inner(nullptr) {
+    Inner = Str.Inner;
+    // reset other
+    Str.Inner=nullptr;
+}
+
+TStr::TStr(const TChA& ChA): Inner(nullptr) {
+    if (!ChA.Empty()) {
+        Inner = new char[ChA.Len()+1];
+        strcpy(Inner, ChA.CStr());
+    }
+}
+
+TStr::TStr(const TMem& Mem): Inner(nullptr) {
+    if (!Mem.Empty()) {
+    const int Len = Mem.Len();
+
+        Inner = new char[Len + 1];
+        memcpy(Inner, Mem(), Len);
+    Inner[Len] = 0;
+    }
+}
+
+TStr::TStr(const TSStr& SStr): Inner(nullptr) {
+  if (!SStr.Empty()) {
+    Inner = new char[SStr.Len()+1];
+    strcpy(Inner, SStr.CStr());
+  }
+}
+
+TStr::TStr(const PSIn& SIn): Inner(nullptr) {
+  const int SInLen = SIn->Len();
+  if (SInLen > 0) {
+    Inner = new char[SInLen + 1];
+    SIn->GetBf(Inner, SInLen);
+    Inner[SInLen] = 0;
+  }
+}
+
+TStr::TStr(TSIn& SIn, const bool& IsSmall): Inner(nullptr) {
+  if (IsSmall) {
+    if (SIn.PeekCh() == 0) {
+            EAssert(SIn.GetCh() == 0);
+        } else {
+      SIn.Load(Inner);
+    }
+  } else {
+    int BfL; SIn.Load(BfL);
+    if (BfL == 0) {
+            EAssert(SIn.GetCh() == 0);
+        } else {
+      SIn.Load(Inner, BfL, BfL);
+    }
+  }
+    // delete buffer and replace with null in case it's ""
+    if (Inner != nullptr && Inner[0] == 0) {
+    delete[] Inner;
+        Inner = nullptr;
+    }
+}
+
+void TStr::Load(TSIn& SIn, const bool& IsSmall) {
+    *this = TStr(SIn, IsSmall);
+}
+
+void TStr::Save(TSOut& SOut, const bool& IsSmall) const {
+    if (IsSmall){ SOut.Save(CStr()); }
+    else { const int BfL = Len(); SOut.Save(BfL); SOut.Save(CStr(), BfL); }
 }
 
 void TStr::LoadXml(const PXmlTok& XmlTok, const TStr& Nm){
@@ -749,182 +776,448 @@ void TStr::SaveXml(TSOut& SOut, const TStr& Nm) const {
   else {XSaveHd(Nm); SOut.PutStr(XmlStr);}
 }
 
-TStr& TStr::ToUc(){
-  TRStr* NewRStr=new TRStr(RStr->CStr()); NewRStr->ToUc();
-  RStr->UnRef(); RStr=NewRStr; RStr->MkRef();
-  Optimize(); return *this;
+TStr& TStr::operator=(const TStr& Str) {
+  if (this != &Str) {
+    Clr();
+    if (!Str.Empty()) {
+      Inner = Str.CloneCStr();
+    }
+  }
+    return *this;
 }
 
-TStr& TStr::ToLc(){
-  TRStr* NewRStr=new TRStr(RStr->CStr()); NewRStr->ToLc();
-  RStr->UnRef(); RStr=NewRStr; RStr->MkRef();
-  Optimize(); return *this;
+TStr& TStr::operator=(TStr&& Str) {
+  if (this != &Str) {
+    std::swap(Inner, Str.Inner);
+    Str.Clr();
+  }
+    return *this;
 }
 
-TStr& TStr::ToCap(){
-  TRStr* NewRStr=new TRStr(RStr->CStr()); NewRStr->ToCap();
-  RStr->UnRef(); RStr=NewRStr; RStr->MkRef();
-  Optimize(); return *this;
+TStr& TStr::operator=(const TChA& ChA) {
+  Clr();
+  if (!ChA.Empty()) {
+    Inner = new char[ChA.Len() + 1];
+    strcpy(Inner, ChA.CStr());
+  }
+    return *this;
 }
 
-TStr& TStr::ToTrunc(){
-  int ThisLen=Len(); char* ThisBf=CStr();
-  int BChN=0; int EChN=ThisLen-1;
-  while ((BChN<ThisLen)&&TCh::IsWs(ThisBf[BChN])){BChN++;}
-  while ((EChN>=0)&&TCh::IsWs(ThisBf[EChN])){EChN--;}
-  *this=GetSubStr(BChN, EChN);
+TStr& TStr::operator=(const char* CStr) {
+  Clr();
+  const int StrLen = (int)strlen(CStr);
+  if (StrLen > 0) {
+    Inner = new char[StrLen+1];
+    strcpy(Inner, CStr);
+  }
   return *this;
 }
 
-TStr& TStr::ConvUsFromYuAscii(){
-  TRStr* NewRStr=new TRStr(RStr->CStr()); NewRStr->ConvUsFromYuAscii();
-  RStr->UnRef(); RStr=NewRStr; RStr->MkRef();
-  Optimize(); return *this;
+bool TStr::operator==(const char* _CStr) const {
+  if (_CStr == nullptr) { return false; }
+  return (CStr() == _CStr) || (strcmp(CStr(), _CStr) == 0);
 }
 
-TStr& TStr::ToHex(){
+bool TStr::operator<(const TStr& Str) const {
+    return strcmp(CStr(), Str.CStr()) < 0;
+}
+
+char& TStr::operator[](const int& ChN) {
+  Assert( (0 <= ChN) && (ChN < Len()) );
+  return Inner[ChN];
+}
+
+void TStr::PutCh(const int& ChN, const char& Ch) {
+    Assert((0<=ChN)&&(ChN<Len()));
+    Inner[ChN] = Ch;
+}
+
+char TStr::GetCh(const int& ChN) const {
+    // Assert index not negative, index not >= Length
+    Assert( (0 <= ChN) && (ChN < Len()) );
+    return Inner[ChN];
+}
+
+char* TStr::CloneCStr() const {
+  const int Length = Len();
+  char* Bf = new char[Length+1];
+  if (Length > 0) {
+    strcpy(Bf, Inner);
+  } else {
+    Bf[0] = 0;
+  }
+  return Bf;
+}
+
+bool TStr::Empty() const {
+   AssertR(Inner == nullptr || Inner[0] != 0, "TStr::Empty string is not nullptr. Fix immediately!");
+   return  Inner == nullptr;
+}
+
+void TStr::Clr() {
+  if (Inner != nullptr) {
+    delete[] Inner;
+    Inner = nullptr;
+  }
+}
+
+int TStr::GetMemUsed() const {
+    return int(sizeof(TStr) + (Empty() ? 0 : (Len() + 1)));
+}
+
+int TStr::CmpI(const char* p, const char* r) {
+  if (!p){ return r ? (*r ? -1 : 0) : 0; }
+  if (!r){ return (*p ? 1 : 0); }
+  while (*p && *r){
+    int i = int(toupper(*p++)) - int(toupper(*r++));
+    if (i != 0){ return i; }
+  }
+  return int(toupper(*p++)) - int(toupper(*r++));
+}
+
+bool TStr::IsUc() const {
+  const int StrLen = Len();
+  for (int ChN = 0; ChN<StrLen; ChN++){
+    if (('a' <= Inner[ChN]) && (Inner[ChN] <= 'z')){ return false; }
+  }
+  return true;
+}
+
+TStr& TStr::ToUc() {
+  const int StrLen = Len();
+  for (int ChN = 0; ChN<StrLen; ChN++){
+        Inner[ChN] = toupper(Inner[ChN]);
+  }
+  return *this;
+}
+
+TStr TStr::GetUc() const {
+    return TStr(*this).ToUc();
+}
+
+bool TStr::IsLc() const {
+  const int StrLen = Len();
+  for (int ChN = 0; ChN<StrLen; ChN++){
+    if (('A' <= Inner[ChN]) && (Inner[ChN] <= 'Z')){ return false; }
+  }
+  return true;
+}
+
+TStr& TStr::ToLc() {
+  const int StrLen = Len();
+  for (int ChN = 0; ChN<StrLen; ChN++){
+        Inner[ChN] = tolower(Inner[ChN]);
+  }
+  return *this;
+}
+
+TStr TStr::GetLc() const {
+    return TStr(*this).ToLc();
+}
+
+TStr& TStr::ToCap() {
+  if (Empty()) { return *this; }
+  const int StrLen = Len();
+  // copy first char in uppercase
+  Inner[0] = (char)toupper(Inner[0]);
+  // copy all other chars in lowercase
+  for (int ChN = 1; ChN < StrLen; ChN++){
+    Inner[ChN] = (char)tolower(Inner[ChN]);
+  }
+  return *this;
+}
+
+TStr TStr::GetCap() const{
+  return TStr(*this).ToCap();
+}
+
+TStr& TStr::ToTrunc() {
+    *this = GetTrunc();
+    return *this;
+}
+
+TStr TStr::GetTrunc() const {
+  int ThisLen = Len();
+
+  int BChN = 0;
+  int EChN = ThisLen - 1;
+
+  while ((BChN < ThisLen) && TCh::IsWs(GetCh(BChN))) { BChN++; }
+  while ((EChN >= 0) && TCh::IsWs(GetCh(EChN))){ EChN--; }
+  if (BChN > EChN) { return TStr(); }
+  return GetSubStr(BChN, EChN);
+}
+
+TStr& TStr::ToHex() {
+    *this = GetHex();
+    return *this;
+}
+
+TStr TStr::GetHex() const {
   TChA ChA;
   int StrLen=Len();
   for (int ChN=0; ChN<StrLen; ChN++){
-    uchar Ch=uchar(RStr->Bf[ChN]);
+    uchar Ch=uchar(GetCh(ChN));
     char MshCh=TCh::GetHexCh((Ch/16)%16);
     char LshCh=TCh::GetHexCh(Ch%16);
     ChA+=MshCh; ChA+=LshCh;
   }
-  *this=ChA;
-  return *this;
+  return TStr(ChA);
 }
 
-TStr& TStr::FromHex(){
+
+TStr& TStr::FromHex() {
+    *this = GetFromHex();
+    return *this;
+}
+
+TStr TStr::GetFromHex() const {
   int StrLen=Len(); IAssert(StrLen%2==0);
   TChA ChA; int ChN=0;
   while (ChN<StrLen){
-    char MshCh=RStr->Bf[ChN]; ChN++;
-    char LshCh=RStr->Bf[ChN]; ChN++;
+  char MshCh = GetCh(ChN); ChN++;
+  char LshCh = GetCh(ChN); ChN++;
     uchar Ch=uchar(TCh::GetHex(MshCh)*16+TCh::GetHex(LshCh));
+  EAssertR(Ch != 0, "TStr::GetFromHex null terminator found! ");
     ChA+=Ch;
   }
-  *this=ChA;
-  return *this;
+  return TStr(ChA);
 }
 
-TStr TStr::GetSubStr(const int& _BChN, const int& _EChN) const {
-  int StrLen=Len();
-  int BChN=TInt::GetMx(_BChN, 0);
-  int EChN=TInt::GetMn(_EChN, StrLen-1);
-  int Chs=EChN-BChN+1;
-  if (Chs<=0){return TStr();}
-  else if (Chs==StrLen){return *this;}
+TStr TStr::GetSubStr(const int& BChN, const int& EChN) const {
+  int StrLen = Len();
+  EAssertR(0 <= BChN && BChN <= EChN && EChN < StrLen, "TStr::GetSubStr index out of bounds");
+  int Chs = EChN - BChN + 1;
+  // initialize accordingly
+  char* Bf = nullptr;
+  if (Chs <= 0) {
+    // create empty string
+    return TStr();
+  }
+  else if (Chs == StrLen) {
+    // keep copy of everything
+    Bf = CloneCStr();//
+  }
   else {
-    char* Bf=new char[Chs+1]; strncpy(Bf, CStr()+BChN, Chs); Bf[Chs]=0;
-    TStr Str(Bf); delete[] Bf;
-    return Str;
+    // get copy of a substring
+    Bf = new char[Chs + 1]; strncpy(Bf, CStr() + BChN, Chs); Bf[Chs] = 0;
   }
+  return WrapCStr(Bf);
 }
 
-void TStr::InsStr(const int& BChN, const TStr& Str){
-  int ThisLen=Len();
-  IAssert((0<=BChN)&&(BChN<=ThisLen));
-  TStr NewStr;
-  if (BChN==0){
-    NewStr=Str+*this;
-  } else
-  if (BChN==ThisLen){
-    NewStr=*this+Str;
-  } else {
-    NewStr=GetSubStr(0, BChN-1)+Str+GetSubStr(BChN, ThisLen-1);
-  }
-  *this=NewStr;
+// safe version of GetSubStr().
+// Fixes BChN and EChN values that are outside of string's range
+// supports also negative indices (python like):
+// GetSubStrSafe(0,-1) will return all but last char
+TStr TStr::GetSubStrSafe(const int& BChN, const int& EChN) const {
+  int StrLen = Len();
+  int StartN;
+  if (BChN <= -StrLen)
+    StartN = 0;
+  else if (BChN < 0)
+    StartN = StrLen + BChN;
+  else
+    StartN = BChN;
+  int EndN;
+  if (EChN < 0)
+    EndN = StrLen + EChN - 1;
+  else
+    EndN = EChN >= StrLen ? StrLen - 1 : EChN;
+
+  if (!(0 <= StartN && StartN <= EndN && EndN < StrLen))
+    return TStr();
+  return GetSubStr(StartN, EndN);
 }
 
-void TStr::DelChAll(const char& Ch){
-  TChA ChA(*this);
-  int ChN=ChA.SearchCh(Ch);
-  while (ChN!=-1){
-    ChA.Del(ChN);
-    ChN=ChA.SearchCh(Ch);
-  }
-  *this=ChA;
+void TStr::InsStr(const int& BChN, const TStr& Str) {
+    const int ThisLen = Len();
+    EAssert((0<=BChN)&&(BChN<=ThisLen));
+    TChA ChA = TChA(ThisLen + Str.Len());
+    if (BChN==0){
+        ChA += Str;
+        ChA += CStr();
+    } else if (BChN==ThisLen){
+        ChA += CStr();
+        ChA += Str;
+    } else {
+        ChA += GetSubStr(0, BChN-1);
+        ChA += Str;
+        ChA += GetSubStr(BChN, ThisLen-1);
+    }
+    *this = ChA;
 }
 
-void TStr::DelSubStr(const int& _BChN, const int& _EChN){
-  int BChN=TInt::GetMx(_BChN, 0);
-  int EChN=TInt::GetMn(_EChN, Len()-1);
-  int Chs=Len()-(EChN-BChN+1);
-  if (Chs==0){Clr();}
-  else if (Chs<Len()){
-    char* Bf=new char[Chs+1]; strncpy(Bf, CStr(), BChN);
-    strncpy(Bf+BChN, CStr()+EChN+1, Len()-EChN-1); Bf[Chs]=0;
-    TStr Str(Bf); delete[] Bf;
-    *this=Str;
-  }
+void TStr::DelChAll(const char& DelCh) {
+    const int ThisLen = Len();
+    TChA ChA = TChA(ThisLen);
+    for (int ChN = 0; ChN < ThisLen; ChN++) {
+        const char Ch = GetCh(ChN);
+        if (Ch != DelCh) { ChA += Ch; }
+    }
+    *this = ChA;
 }
 
-bool TStr::DelStr(const TStr& Str){
-  int ChN=SearchStr(Str);
-  if (ChN==-1){
+void TStr::DelSubStr(const int& BChN, const int& EChN) {
+  int StrLen = Len();
+  EAssertR(0 <= BChN && BChN <= EChN && EChN < StrLen, "TStr::DelSubStr index out of bounds");
+
+    int Chs = Len() - (EChN - BChN + 1);
+    if (Chs == 0) {
+        // nothing left after delete, clear it all
+        Clr();
+    } else if (Chs < Len()) {
+        // actual substring
+        char* Bf=new char[Chs + 1];
+        // copy before
+        strncpy(Bf, CStr(), BChN);
+        // copy after
+        strncpy(Bf+BChN, CStr()+EChN+1, Len()-EChN-1);
+        // we are done, just replace current
+        Bf[Chs]=0;
+        *this = WrapCStr(Bf);
+    }
+}
+
+bool TStr::DelStr(const TStr& Str) {
+  int ChN = SearchStr(Str);
+  if (ChN != -1){
+    DelSubStr(ChN, ChN + Str.Len() - 1);
+        return true;
+  }
     return false;
-  } else {
-    DelSubStr(ChN, ChN+Str.Len()-1);
-    return true;
-  }
+}
+
+int TStr::DelStrAll(const TStr& Str) {
+  return ChangeStrAll(Str, "");
 }
 
 TStr TStr::LeftOf(const char& SplitCh) const {
   int ThisLen=Len(); const char* ThisBf=CStr();
   int ChN=0;
   while ((ChN<ThisLen)&&(ThisBf[ChN]!=SplitCh)){ChN++;}
-  return (ChN==ThisLen) ? "" : GetSubStr(0, ChN-1);
+  return (ChN == 0 || ChN==ThisLen) ? "" : GetSubStr(0, ChN-1);
 }
 
 TStr TStr::LeftOfLast(const char& SplitCh) const {
   const char* ThisBf=CStr();
   int ChN=Len()-1;
   while ((ChN>=0)&&(ThisBf[ChN]!=SplitCh)){ChN--;}
-  return (ChN==-1) ? "" : GetSubStr(0, ChN-1);
+  return (ChN == 0 || ChN == -1) ? "" : GetSubStr(0, ChN - 1);
 }
 
 TStr TStr::RightOf(const char& SplitCh) const {
   int ThisLen=Len(); const char* ThisBf=CStr();
   int ChN=0;
   while ((ChN<ThisLen)&&(ThisBf[ChN]!=SplitCh)){ChN++;}
-  return (ChN==ThisLen) ? "" : GetSubStr(ChN+1, ThisLen-1);
+  return (ChN>=ThisLen - 1) ? "" : GetSubStr(ChN+1, ThisLen-1);
 }
 
 TStr TStr::RightOfLast(const char& SplitCh) const {
   int ThisLen=Len(); const char* ThisBf=CStr();
   int ChN=Len()-1;
   while ((ChN>=0)&&(ThisBf[ChN]!=SplitCh)){ChN--;}
-  return (ChN==-1) ? "" : GetSubStr(ChN+1, ThisLen-1);
+  return (ChN == ThisLen -1 || ChN==-1) ? "" : GetSubStr(ChN+1, ThisLen-1);
+}
+
+void TStr::SplitLeftOfRightOf(TStr& LStr, const int& LeftOfChN, const int& RightOfChN, TStr& RStr) const {
+  const int StrLen = Len();
+
+  EAssertR(LeftOfChN >= 0 && LeftOfChN <= RightOfChN && RightOfChN < StrLen, "Splitting index should be greater than 0 and less than length!");
+
+  // clear the left and right strings
+  LStr.Clr();
+  RStr.Clr();
+
+  if (Empty()) { return; }
+
+  const char* InnerPt = CStr();
+
+  const int LeftLen = LeftOfChN;
+  const int RightLen = StrLen - RightOfChN - 1;
+
+  // copy into left and right
+  // if the length of any of the strings is 0 than leave it empty
+  if (LeftLen > 0) {
+    LStr.Inner = new char[LeftLen + 1];
+    memcpy(LStr.Inner, InnerPt, LeftLen);
+    LStr.Inner[LeftLen] = 0;
+  }
+  if (RightLen > 0) {
+    RStr.Inner = new char[RightLen + 1];
+    memcpy(RStr.Inner, InnerPt + RightOfChN + 1, RightLen);
+    RStr.Inner[RightLen] = 0;
+  }
+}
+
+void TStr::SplitOnChN(TStr& LStr, const int& ChN, TStr& RStr) const {
+  SplitLeftOfRightOf(LStr, ChN, ChN, RStr);
 }
 
 void TStr::SplitOnCh(TStr& LStr, const char& SplitCh, TStr& RStr) const {
-  int ThisLen=Len(); const char* ThisBf=CStr();
-  int ChN=0;
-  while ((ChN<ThisLen)&&(ThisBf[ChN]!=SplitCh)){ChN++;}
-  if (ChN==ThisLen){
-    LStr=GetSubStr(0, ThisLen-1); RStr="";
-  } else {
-    LStr=GetSubStr(0, ChN-1); RStr=GetSubStr(ChN+1, ThisLen-1);
+  LStr.Clr();
+  RStr.Clr();
+
+  // check if the string is empty
+  if (Empty()) { return; }
+
+  const char* InnerPt = CStr();
+
+  // find the pointer to the delimiter
+  const char* ChPtr = strchr(InnerPt, SplitCh);
+
+  // if the character was not found than return this in the left string
+  if (ChPtr == nullptr) {
+    LStr = *this;
+    return;
   }
+
+  // split
+  SplitOnChN(LStr, (int)(ChPtr - InnerPt), RStr);
+}
+
+void TStr::SplitOnStr(TStr& LStr, const TStr& SplitStr, TStr& RStr) const {
+  LStr.Clr();
+  RStr.Clr();
+
+  // check if the string is empty
+  if (Empty()) { return; }
+
+  const char* InnerPt = CStr();
+
+  const char* MatchPt = strstr(InnerPt, SplitStr.CStr());
+
+  if (MatchPt == nullptr || SplitStr.Empty()) {
+    LStr = *this;
+    return;
+  }
+
+  const int MatchIdx = (int)(MatchPt - InnerPt);
+
+  SplitLeftOfRightOf(LStr, MatchIdx, MatchIdx + SplitStr.Len() - 1, RStr);
 }
 
 void TStr::SplitOnLastCh(TStr& LStr, const char& SplitCh, TStr& RStr) const {
-  int ThisLen=Len(); const char* ThisBf=CStr();
-  int ChN=Len()-1;
-  while ((ChN>=0)&&(ThisBf[ChN]!=SplitCh)){ChN--;}
-  if (ChN==-1){
-    LStr=""; RStr=*this;
-  } else
-  if (ChN==0){
-    LStr=""; RStr=GetSubStr(1, ThisLen-1);
-  } else {
-    LStr=GetSubStr(0, ChN-1); RStr=GetSubStr(ChN+1, ThisLen-1);
+  LStr.Clr();
+  RStr.Clr();
+  // check if the string is empty
+  if (Empty()) { return; }
+
+  const char* InnerPt = CStr();
+
+  // find the pointer to the delimiter
+  const char* ChPtr = strrchr(InnerPt, SplitCh);
+
+  // if the character was not found than return this in the right string
+  if (ChPtr == nullptr) {
+    RStr = *this;
+    return;
   }
+
+  // split
+  SplitOnChN(LStr, (int)(ChPtr - InnerPt), RStr);
 }
 
-void TStr::SplitOnAllCh(
- const char& SplitCh, TStrV& StrV, const bool& SkipEmpty) const {
+void TStr::SplitOnAllCh(const char& SplitCh, TStrV& StrV, const bool& SkipEmpty) const {
   StrV.Clr();
   char* Bf=new char[Len()+1];
   strcpy(Bf, CStr());
@@ -1009,145 +1302,220 @@ void TStr::SplitOnStr(const TStr& SplitStr, TStrV& StrV) const {
   StrV.Clr();
   int SplitStrLen=SplitStr.Len();
   int PrevChN=0; int ChN=0;
-  while ((ChN=SearchStr(SplitStr, ChN))!=-1){
+  int StrLen = Len();
+  // on empty string we need to end here, otherwise the GetSubStr crashes
+  if (StrLen == 0) { return; }
+  while (ChN < StrLen && (ChN = SearchStr(SplitStr, ChN)) != -1){
     // extract & add string
-    TStr SubStr=GetSubStr(PrevChN, ChN-1);
-    StrV.Add(SubStr);
-    PrevChN=ChN=ChN+SplitStrLen;
+    if (ChN - 1 >= 0 && ChN - 1 < StrLen) {
+      TStr SubStr = GetSubStr(PrevChN, ChN - 1);
+      StrV.Add(SubStr);
+    }
+  PrevChN = ChN;
+  ChN += SplitStrLen;
   }
   // add last string
-  TStr LastSubStr=GetSubStr(PrevChN, Len()-1);
+  TStr LastSubStr=GetSubStr(PrevChN, StrLen-1);
   StrV.Add(LastSubStr);
 }
 
-void TStr::SplitOnStr(TStr& LeftStr, const TStr& MidStr, TStr& RightStr) const {
-  const int ChN=SearchStr(MidStr);
-  if (ChN==-1){
-    LeftStr=*this; RightStr=GetNullStr();
-  } else {
-    LeftStr=GetSubStr(0, ChN-1);
-    RightStr=GetSubStr(ChN+MidStr.Len(), Len()-1);
-  }
+TStr TStr::Left(const int& EChN) const {
+  if (EChN == 0) { return ""; }
+  return EChN>=0 ? GetSubStr(0, EChN-1) : GetSubStr(0, Len()+EChN-1);
 }
 
 int TStr::CountCh(const char& Ch, const int& BChN) const {
-  const int ThisLen=Len();
-  const char* ThisBf=CStr();
-  int Chs=0;
-  for (int ChN=TInt::GetMx(BChN, 0); ChN<ThisLen; ChN++){
-    if (ThisBf[ChN]==Ch){Chs++;}
+  const int ThisLen = Len();
+  if(ThisLen == 0) { return 0; }
+  EAssertR(BChN >= 0 && BChN < ThisLen, "TStr::CountCh index BChN out of bounds!");
+
+  const char* ThisBf = CStr();
+  int Chs = 0;
+
+  for (int ChN = BChN; ChN<ThisLen; ChN++) {
+    if (ThisBf[ChN]==Ch) { Chs++; }
   }
   return Chs;
 }
 
 int TStr::SearchCh(const char& Ch, const int& BChN) const {
-  int ThisLen=Len(); const char* ThisBf=CStr();
-  int ChN=TInt::GetMx(BChN, 0);
-  while (ChN<ThisLen){
-    if (ThisBf[ChN]==Ch){return ChN;}
+  int ThisLen = Len();
+  if(ThisLen == 0) { return -1; }
+  EAssertR(BChN >= 0 && BChN < ThisLen, "TStr::SearchCh index BChN out of bounds!");
+
+  const char* ThisBf = CStr();
+  int ChN = BChN;
+
+  while (ChN < ThisLen){
+    if (ThisBf[ChN] == Ch){ return ChN; }
     ChN++;
   }
   return -1;
 }
 
 int TStr::SearchChBack(const char& Ch, int BChN) const {
-  const int StrLen=Len();
-  if (BChN==-1||BChN>=StrLen){BChN=StrLen-1;}
-  const char* ThisBf=CStr();
-  const char* Pt=ThisBf + BChN;
-  while (Pt>=ThisBf) {
-    if (*Pt==Ch){return (int)(Pt-ThisBf);}
+  const int StrLen = Len();
+  if (StrLen == 0) { return 0; }
+  const char* ThisBf = CStr();
+
+  if (BChN < 0 || BChN >= StrLen) { BChN = StrLen - 1; }
+
+  const char* Pt = ThisBf + BChN;
+
+  while (Pt >= ThisBf) {
+    if (*Pt == Ch){ return (int) (Pt - ThisBf); }
     Pt--;
   }
   return -1;
 }
 
 int TStr::SearchStr(const TStr& Str, const int& BChN) const {
-  int NrBChN=TInt::GetMx(BChN, 0);
-  const char* StrPt=strstr((const char*)CStr()+NrBChN, Str.CStr());
-  if (StrPt==NULL){return -1;}
-  else {return int(StrPt-CStr());}
-/*  // slow implementation
-  int ThisLen=Len(); int StrLen=Str.Len();
-  int ChN=TInt::GetMx(BChN, 0);
-  while (ChN<ThisLen-StrLen+1){
-    if (strncmp(CStr()+ChN, Str.CStr(), StrLen)==0){
-      return ChN;}
-    ChN++;
+  const int ThisLen = Len();
+  EAssertR(BChN >= 0 && BChN <= ThisLen, "TStr::SearchStr: index BChN out of bounds!");
+
+  // special case for handling empty strings
+  if (ThisLen == 0) { return Str.Empty() ? 0 : -1; }
+
+  const int NrBChN = BChN;
+  const char* StrPt = strstr((const char*) CStr() + NrBChN, Str.CStr());
+  if (StrPt == nullptr) { return -1; }
+  return int(StrPt - CStr());
+}
+
+bool TStr::StartsWith(const char *Str) const {
+  const int OtherLen = (int)strlen(Str);
+  const int ThisLen = Len();
+  if (OtherLen > ThisLen || ThisLen == 0) { return false; }
+
+  int Cmp = strncmp(Str, CStr(), OtherLen);
+  return Cmp == 0;
+}
+
+bool TStr::EndsWith(const char *Str) const {
+  const int OtherLen = (int)strlen(Str);
+  const int ThisLen = Len();
+  if (OtherLen > ThisLen) {
+    // too long to be a suffix anyway
+    return false;
+  } else {
+    // move to the point in the buffer where we would expect the suffix to be
+    const char *ending = CStr() + ThisLen - OtherLen;
+    int cmp = strncmp(Str, ending, OtherLen);
+    return cmp == 0;
   }
-  return -1;*/
 }
 
-bool TStr::IsPrefix(const char *Str) const {
-	size_t len = strlen(Str);
-	size_t thisLen = Len();
-	if (len > thisLen) {
-		return false;
-	} else {
-        size_t minLen = MIN(len, thisLen);
-		int cmp = strncmp(Str, RStr->Bf, minLen);
-		return cmp == 0;
-	}
-}
-
-bool TStr::IsSuffix(const char *Str) const {
-	size_t len = strlen(Str);
-	size_t thisLen = Len();
-	if (len > thisLen) {
-		// too long to be a suffix anyway
-		return false;
-	} else {
-		// move to the point in the buffer where we would expect the suffix to be
-		const char *ending = RStr->Bf + thisLen - len;
-		int cmp = strncmp(Str, ending, len);
-		return cmp == 0;
-	}
-}
-
-int TStr::ChangeCh(const char& SrcCh, const char& DstCh, const int& BChN){
-  int ChN=SearchCh(SrcCh, BChN);
-  if (ChN!=-1){PutCh(ChN, DstCh);}
+int TStr::ChangeCh(const char& SrcCh, const char& DstCh, const int& BChN) {
+  AssertR(SrcCh != '\0' && DstCh != '\0', "TStr::ChangeCh: source and destination character should not be the terminator char!");
+  int ChN = SearchCh(SrcCh, BChN);
+  if (ChN != -1) { PutCh(ChN, DstCh); }
   return ChN;
 }
 
-int TStr::ChangeChAll(const char& SrcCh, const char& DstCh){
-  int FirstChN=SearchCh(SrcCh);
-  if (FirstChN==-1){
+int TStr::ChangeChAll(const char& SrcCh, const char& DstCh) {
+  if (Empty()) { return 0; }
+  int FirstChN = SearchCh(SrcCh);
+  if (FirstChN == -1){
     return 0;
   } else {
-    TRStr* NewRStr=new TRStr(RStr->CStr());
-    RStr->UnRef(); RStr=NewRStr; RStr->MkRef();
-    char* ThisBf=CStr(); int StrLen=Len(); int Changes=0;
-    for (int ChN=FirstChN; ChN<StrLen; ChN++){
-      // slow: if (GetCh(ChN)==SrcCh){RStr->PutCh(ChN, DstCh); Changes++;}
-      if (ThisBf[ChN]==SrcCh){ThisBf[ChN]=DstCh; Changes++;}
+    const int StrLen = Len(); int Changes = 0;
+    for (int ChN = FirstChN; ChN < StrLen; ChN++){
+            if (GetCh(ChN) == SrcCh) { PutCh(ChN, DstCh); Changes++; }
     }
-    Optimize();
     return Changes;
   }
 }
 
-int TStr::ChangeStr(const TStr& SrcStr, const TStr& DstStr, const int& BChN){
-  int ChN=SearchStr(SrcStr, BChN);
-  if (ChN==-1){
-    return -1;
-  } else {
-    DelSubStr(ChN, ChN+SrcStr.Len()-1);
-    InsStr(ChN, DstStr);
-    return ChN;
+int TStr::ChangeStr(const TStr& SrcStr, const TStr& DstStr, const int& BChN) {
+  if (Empty() && BChN == 0) { return -1; }
+  const int ChN = SearchStr(SrcStr, BChN);
+  if (ChN != -1){
+        DelSubStr(ChN, ChN + SrcStr.Len() - 1);
+        InsStr(ChN, DstStr);
   }
+    return ChN;
 }
 
-int TStr::ChangeStrAll(const TStr& SrcStr, const TStr& DstStr, const bool& FromStartP){
-  const int DstStrLen=DstStr.Len();
-  int Changes=0-1; int BChN=0-DstStrLen;
-  do {
-    Changes++;
-    if (FromStartP){BChN=0-DstStrLen;}
-    BChN+=DstStrLen;
-    BChN=ChangeStr(SrcStr, DstStr, BChN);
-  } while (BChN!=-1);
-  return Changes;
+int TStr::ChangeStrAll(const TStr& SrcStr, const TStr& DstStr) {
+  if (Empty() || SrcStr.Empty()) { return 0; }
+
+  const int Length = Len();
+  const int SrcLen = SrcStr.Len();
+  const int DstLen = DstStr.Len();
+
+  const char* InnerPt = CStr();
+  const char* SrcCStr = SrcStr.CStr();
+  const char* DstCStr = DstStr.CStr();
+
+  // find how many times SrcStr appears in this string
+  const char* CurrPos = Inner;
+  const char* NextHit;
+
+  int NMatches = 0;
+  while ((NextHit = strstr(CurrPos, SrcCStr)) != nullptr) {
+    NMatches++;
+    CurrPos = NextHit + SrcLen;
+  }
+
+  // create a new string
+  char* ResStr = new char[Length + NMatches*(DstLen - SrcLen) + 1];
+
+  // iterate through the string, instead of copying source copy destination
+  int i = 0;  // index in the source string
+  int j = 0;  // index in the result string
+
+  int SeqLen;
+
+  // find next hit, copy everything between the current position and the hit,
+  // then copy the dest string
+  while ((NextHit = strstr(InnerPt + i, SrcCStr)) != nullptr) {
+    SeqLen = (int)(NextHit - (InnerPt + i));
+    // copy the chars in between the hits
+    memcpy(ResStr + j, InnerPt + i, SeqLen);
+
+    // increase positions
+    i += SeqLen;
+    j += SeqLen;
+
+    // copy the dst string
+    memcpy(ResStr + j, DstCStr, DstLen);
+
+    // increase positions
+    i += SrcLen;
+    j += DstLen;
+  }
+
+  // copy what is after the last match
+  memcpy(ResStr + j, InnerPt + i, Length - i);
+
+  // insert null character
+  ResStr[Length + NMatches*(DstLen - SrcLen)] = 0;
+  // replace with the new string
+  *this = WrapCStr(ResStr);
+    // return number of changes
+    return NMatches;
+}
+
+TStr TStr::Reverse() const {
+  const int ThisLen = Len();
+    // reserve place for reverse
+  char* Reversed = new char[ThisLen+1];
+    // do the reversing
+    for (int ChN = 0; ChN < ThisLen; ChN++) {
+    Reversed[ChN] = Inner[ThisLen - ChN - 1];
+  }
+    // finish
+  Reversed[ThisLen] = 0;
+    // create new string from it
+  return WrapCStr(Reversed);
+}
+
+int TStr::GetPrimHashCd() const {
+    return TStrHashF_DJB::GetPrimHashCd(CStr());
+}
+
+int TStr::GetSecHashCd() const {
+    return TStrHashF_DJB::GetSecHashCd(CStr());
 }
 
 bool TStr::IsBool(bool& Val) const {
@@ -1156,42 +1524,23 @@ bool TStr::IsBool(bool& Val) const {
   else {return false;}
 }
 
-bool TStr::IsInt(
- const bool& Check, const int& MnVal, const int& MxVal, int& Val) const {
-  // parsing format {ws} [+/-] +{ddd}
-  int _Val=0;
-  bool Minus=false;
-  TChRet Ch(TStrIn::New(*this));
-  while (TCh::IsWs(Ch.GetCh())){}
-  if (Ch()=='+'){Minus=false; Ch.GetCh();}
-  if (Ch()=='-'){Minus=true; Ch.GetCh();}
-  if (!TCh::IsNum(Ch())){return false;}
-  _Val=TCh::GetNum(Ch());
-  while (TCh::IsNum(Ch.GetCh())){_Val=10*_Val+TCh::GetNum(Ch());}
-  if (Minus){_Val=-_Val;}
-  if (Check&&((_Val<MnVal)||(_Val>MxVal))){return false;}
-  if (Ch.Eof()){Val=_Val; return true;} else {return false;}
+bool TStr::IsInt(const bool& Check, const int& MnVal, const int& MxVal, int& Val) const {
+  int64 _Val;
+  // assign and check for overflow
+  return IsInt64(Check, MnVal, MxVal, _Val) && (int64)(Val = (int)_Val) == _Val;
 }
 
-bool TStr::IsUInt(
- const bool& Check, const uint& MnVal, const uint& MxVal, uint& Val) const {
-  // parsing format {ws} [+]{ddd}
-  uint _Val=0;
-  TChRet Ch(TStrIn::New(*this));
-  while (TCh::IsWs(Ch.GetCh())){}
-  if (Ch()=='+'){Ch.GetCh();}
-  if (!TCh::IsNum(Ch())){return false;}
-  _Val=TCh::GetNum(Ch());
-  while (TCh::IsNum(Ch.GetCh())){_Val=10*_Val+TCh::GetNum(Ch());}
-  if (Check&&((_Val<MnVal)||(_Val>MxVal))){return false;}
-  if (Ch.Eof()){Val=_Val; return true;} else {return false;}
+bool TStr::IsUInt(const bool& Check, const uint& MnVal, const uint& MxVal, uint& Val) const {
+  TChRet Ch(TStrIn::New(*this, false));
+  Ch.GetCh();
+  return IsUInt(Ch, Check, MnVal, MxVal, Val);
 }
 
 bool TStr::IsHexInt( const bool& Check, const int& MnVal, const int& MxVal, int& Val) const {
   // parsing format {ws} [+/-][0x] +{XXX}
   int _Val=0;
   bool Minus=false;
-  TChRet Ch(TStrIn::New(*this));
+  TChRet Ch(TStrIn::New(*this, false));
   while (TCh::IsWs(Ch.GetCh())){}
   if (Ch()=='+'){Minus=false; Ch.GetCh();}
   if (Ch()=='-'){Minus=true; Ch.GetCh();}
@@ -1209,35 +1558,37 @@ bool TStr::IsHexInt( const bool& Check, const int& MnVal, const int& MxVal, int&
   if (Ch.Eof()){Val=_Val; return true;} else {return false;}
 }
 
-bool TStr::IsInt64(
- const bool& Check, const int64& MnVal, const int64& MxVal, int64& Val) const {
+bool TStr::IsInt64(const bool& Check, const int64& MnVal, const int64& MxVal, int64& Val) const {
+  EAssert(!Check || (Check && MnVal <= MxVal));
   // parsing format {ws} [+/-] +{ddd}
-  int64 _Val=0;
-  bool Minus=false;
-  TChRet Ch(TStrIn::New(*this));
-  while (TCh::IsWs(Ch.GetCh())){}
-  if (Ch()=='+'){Minus=false; Ch.GetCh();}
-  if (Ch()=='-'){Minus=true; Ch.GetCh();}
-  if (!TCh::IsNum(Ch())){return false;}
-  _Val=TCh::GetNum(Ch());
-  while (TCh::IsNum(Ch.GetCh())){_Val=10*_Val+TCh::GetNum(Ch());}
-  if (Minus){_Val=-_Val;}
-  if (Check&&((_Val<MnVal)||(_Val>MxVal))){return false;}
-  if (Ch.Eof()){Val=_Val; return true;} else {return false;}
+  TChRet Ch(TStrIn::New(*this, false));
+
+  while (TCh::IsWs(Ch.GetCh())) {}
+
+  bool IsInt;
+  uint64 UIntVal;
+
+  if (Ch() == '-') {
+    Ch.GetCh();
+    IsInt = IsUInt64(Ch, true, 0, 9223372036854775808ul, UIntVal);
+    Val = -1l * UIntVal;
+  } else {
+    if (Ch() == '+') { Ch.GetCh(); }
+    IsInt = IsUInt64(Ch, true, 0, 9223372036854775807ul, UIntVal);
+    Val = UIntVal;
+  }
+
+  // check
+  if (!IsInt) { return false; }
+  if (Check && (Val < MnVal || Val > MxVal)) { return false; }
+
+  return true;
 }
 
-bool TStr::IsUInt64(
- const bool& Check, const uint64& MnVal, const uint64& MxVal, uint64& Val) const {
-  // parsing format {ws} [+]{ddd}
-  uint64 _Val=0;
-  TChRet Ch(TStrIn::New(*this));
-  while (TCh::IsWs(Ch.GetCh())){}
-  if (Ch()=='+'){Ch.GetCh();}
-  if (!TCh::IsNum(Ch())){return false;}
-  _Val=TCh::GetNum(Ch());
-  while (TCh::IsNum(Ch.GetCh())){_Val=10*_Val+TCh::GetNum(Ch());}
-  if (Check&&((_Val<MnVal)||(_Val>MxVal))){return false;}
-  if (Ch.Eof()){Val=_Val; return true;} else {return false;}
+bool TStr::IsUInt64(const bool& Check, const uint64& MnVal, const uint64& MxVal, uint64& Val) const {
+  TChRet Ch(TStrIn::New(*this, false));
+  Ch.GetCh();
+  return IsUInt64(Ch, Check, MnVal, MxVal, Val);
 }
 
 bool TStr::IsHexInt64(
@@ -1245,7 +1596,7 @@ bool TStr::IsHexInt64(
   // parsing format {ws} [+/-][0x] +{XXX}
   int64 _Val=0;
   bool Minus=false;
-  TChRet Ch(TStrIn::New(*this));
+  TChRet Ch(TStrIn::New(*this, false));
   while (TCh::IsWs(Ch.GetCh())){}
   if (Ch()=='+'){Minus=false; Ch.GetCh();}
   if (Ch()=='-'){Minus=true; Ch.GetCh();}
@@ -1265,7 +1616,7 @@ bool TStr::IsHexInt64(
 bool TStr::IsFlt(const bool& Check, const double& MnVal, const double& MxVal,
  double& Val, const char& DecDelimCh) const {
   // parsing format {ws} [+/-] +{d} ([.]{d}) ([E|e] [+/-] +{d})
-  TChRet Ch(TStrIn::New(*this));
+  TChRet Ch(TStrIn::New(*this, false));
   while (TCh::IsWs(Ch.GetCh())){}
   if ((Ch()=='+')||(Ch()=='-')){Ch.GetCh();}
   if (!TCh::IsNum(Ch())&&Ch()!=DecDelimCh){return false;}
@@ -1291,7 +1642,7 @@ bool TStr::IsFlt(const bool& Check, const double& MnVal, const double& MxVal,
 
 bool TStr::IsWord(const bool& WsPrefixP, const bool& FirstUcAllowedP) const {
   // parsing format {ws} (A-Z,a-z) *{A-Z,a-z,0-9}
-  TChRet Ch(TStrIn::New(*this));
+  TChRet Ch(TStrIn::New(*this, false));
   if (WsPrefixP){while (TCh::IsWs(Ch.GetCh())){}}
   else {Ch.GetCh();}
   if (!TCh::IsAlpha(Ch())){return false;}
@@ -1303,7 +1654,7 @@ bool TStr::IsWord(const bool& WsPrefixP, const bool& FirstUcAllowedP) const {
 
 bool TStr::IsWs() const {
   // if string is just a bunch of whitespace chars
-  TChRet Ch(TStrIn::New(*this));
+  TChRet Ch(TStrIn::New(*this, false));
   while (TCh::IsWs(Ch.GetCh())){}
   return Ch.Eof();
 }
@@ -1311,7 +1662,7 @@ bool TStr::IsWs() const {
 bool TStr::IsWcMatch(
  const int& StrBChN, const TStr& WcStr, const int& WcStrBChN, TStrV& StarStrV,
  const char& StarCh, const char& QuestCh) const {
-  int StrLen=Len(); int WcStrLen=WcStr.Len();
+  const int StrLen=Len(), WcStrLen=WcStr.Len();
   int StrChN=StrBChN; int WcStrChN=WcStrBChN;
   while ((StrChN<StrLen)&&(WcStrChN<WcStrLen)){
     if ((WcStr[WcStrChN]==QuestCh)||(GetCh(StrChN)==WcStr[WcStrChN])){
@@ -1387,17 +1738,18 @@ TStr TStr::GetWcMatch(const TStr& WcStr, const int& StarStrN) const {
 }
 
 TStr TStr::GetFPath() const {
-  int ThisLen=Len(); const char* ThisBf=CStr();
+  const int ThisLen=Len(); const char* ThisBf=CStr();
   int ChN=ThisLen-1;
   while ((ChN>=0)&&(ThisBf[ChN]!='/')&&(ThisBf[ChN]!='\\')){ChN--;}
   return GetSubStr(0, ChN);
 }
 
 TStr TStr::GetFBase() const {
-  int ThisLen=Len(); const char* ThisBf=CStr();
+  const int ThisLen=Len(); const char* ThisBf=CStr();
   int ChN=ThisLen-1;
   while ((ChN>=0)&&(ThisBf[ChN]!='/')&&(ThisBf[ChN]!='\\')){ChN--;}
-  return GetSubStr(ChN+1, ThisLen);
+  if (ChN + 1 > ThisLen - 1) { return TStr(); }
+  return GetSubStr(ChN+1, ThisLen - 1);
 }
 
 TStr TStr::GetFMid() const {
@@ -1411,9 +1763,11 @@ TStr TStr::GetFMid() const {
     if (ThisBf[ChN]=='.'){
       int EChN= --ChN;
       while ((ChN>=0)&&(ThisBf[ChN]!='/')&&(ThisBf[ChN]!='\\')){ChN--;}
+    if (ChN + 1 > EChN) { return TStr(); }
       return GetSubStr(ChN+1, EChN);
     } else {
-      return GetSubStr(ChN+1, ThisLen);
+    if (ChN + 1 > ThisLen - 1) { return TStr(); }
+      return GetSubStr(ChN+1, ThisLen - 1);
     }
   }
 }
@@ -1423,8 +1777,10 @@ TStr TStr::GetFExt() const {
   int ChN=ThisLen-1;
   while ((ChN>=0)&&(ThisBf[ChN]!='/')&&(ThisBf[ChN]!='\\')&&
    (ThisBf[ChN]!='.')){ChN--;}
-  if ((ChN>=0)&&(ThisBf[ChN]=='.')){return GetSubStr(ChN, Len());}
-  else {return TStr();}
+  if ((ChN>=0)&&(ThisBf[ChN]=='.')){
+    if (ChN > Len() - 1) { return TStr(); }
+    return GetSubStr(ChN, Len()-1);
+  } else {return TStr();}
 }
 
 TStr TStr::GetNrFPath(const TStr& FPath){
@@ -1457,9 +1813,9 @@ TStr TStr::GetNrFExt(const TStr& FExt){
   else {return TStr(".")+FExt;}
 }
 
-TStr TStr::GetNrNumFExt(const int& FExtN){
+TStr TStr::GetNrNumFExt(const int& FExtN, const int& MinLen){
   TStr FExtNStr=TInt::GetStr(FExtN);
-  while (FExtNStr.Len()<3){
+  while (FExtNStr.Len()<MinLen){
     FExtNStr=TStr("0")+FExtNStr;}
   return FExtNStr;
 }
@@ -1475,7 +1831,7 @@ TStr TStr::GetNrAbsFPath(const TStr& FPath, const TStr& BaseFPath){
   } else {
     NrBaseFPath=GetNrFPath(BaseFPath);
   }
-  IAssert(IsAbsFPath(NrBaseFPath));
+  IAssertR(IsAbsFPath(NrBaseFPath), NrBaseFPath);
   TStr NrFPath=GetNrFPath(FPath);
   TStr NrAbsFPath;
   if (IsAbsFPath(NrFPath)){
@@ -1491,6 +1847,9 @@ TStr TStr::GetNrAbsFPath(const TStr& FPath, const TStr& BaseFPath){
 bool TStr::IsAbsFPath(const TStr& FPath){
   if ((FPath.Len()>=3)&&isalpha(FPath[0])&&(FPath[1]==':')&&
    ((FPath[2]=='/')||(FPath[2]=='\\'))){
+    return true;
+  }
+  if ((FPath.Len()>=2)&&(FPath[0]=='/')&&isalpha(FPath[1])){
     return true;
   }
   return false;
@@ -1548,36 +1907,8 @@ TStr TStr::GetFNmStr(const TStr& Str, const bool& AlNumOnlyP){
   return FNm;
 }
 
-TStr& TStr::GetChStr(const char& Ch){
-  static char MnCh=char(CHAR_MIN);
-  static char MxCh=char(CHAR_MAX);
-  static int Chs=int(MxCh)-int(MnCh)+1;
-  static TStrV ChStrV;
-  if (ChStrV.Empty()){
-    ChStrV.Gen(Chs);
-    for (int ChN=0; ChN<Chs; ChN++){
-      ChStrV[ChN]=TStr(char(MnCh+ChN), true);}
-  }
-  return ChStrV[int(Ch-MnCh)];
-}
-
-TStr& TStr::GetDChStr(const char& Ch1, const char& Ch2){
-  Fail; // temporary
-  static TStrVV DChStrVV;
-  if (DChStrVV.Empty()){
-    DChStrVV.Gen(TCh::Vals, TCh::Vals);
-    for (int Ch1N=0; Ch1N<TCh::Vals; Ch1N++){
-      for (int Ch2N=0; Ch2N<TCh::Vals; Ch2N++){
-        DChStrVV.At(Ch1N, Ch2N)=
-         TStr(char(TCh::Mn+Ch1N), char(TCh::Mn+Ch2N), true);
-      }
-    }
-  }
-  return DChStrVV.At(int(Ch1-TCh::Mn), int(Ch2-TCh::Mn));
-}
-
 TStr TStr::GetStr(const TStr& Str, const char* FmtStr){
-  if (FmtStr==NULL){
+  if (FmtStr==nullptr){
     return Str;
   } else {
     char Bf[1000];
@@ -1602,46 +1933,210 @@ TStr TStr::Fmt(const char *FmtStr, ...){
   va_start(valist, FmtStr);
   const int RetVal=vsnprintf(Bf, 10*1024-2, FmtStr, valist);
   va_end(valist);
-  return RetVal!=-1 ? TStr(Bf) : TStr::GetNullStr();
+  return RetVal!=-1 ? TStr(Bf) : TStr();
 }
 
-TStr TStr::GetSpaceStr(const int& Spaces){
-  static TStrV SpaceStrV;
-  if (SpaceStrV.Len()==0){
-    for (int SpaceStrN=0; SpaceStrN<10; SpaceStrN++){
-      TChA SpaceChA;
-      for (int ChN=0; ChN<SpaceStrN; ChN++){SpaceChA+=' ';}
-      SpaceStrV.Add(SpaceChA);
+TStr TStr::GetSpaceStr(const int& Spaces) {
+    EAssert(Spaces >= 0);
+    if (Spaces == 0) { return TStr(); }
+    // we have more, go for it
+  char *NewBf = new char[Spaces + 1];
+  for (int SpaceN = 0; SpaceN < Spaces; SpaceN++) {
+        NewBf[SpaceN] = ' ';
+    }
+  NewBf[Spaces] = 0;
+  return WrapCStr(NewBf);
+}
+
+TStr operator+(const TStr& LStr, const char* RCStr) {
+  const size_t LeftLen = LStr.Len();
+  const size_t RightLen = ((RCStr == nullptr) ? 0 : strlen(RCStr));
+
+  // check if any of the strings are empty
+  if (LeftLen == 0) { return TStr(RCStr); }
+  else if (RightLen == 0) { return LStr; }
+  else {
+    const char* LCStr = LStr.CStr();
+
+    // allocate memory
+    char* ConcatStr = new char[LeftLen + RightLen + 1];
+
+    // copy the two strings into the new memory
+    memcpy(ConcatStr, LCStr, LeftLen);
+    memcpy(ConcatStr + LeftLen, RCStr, RightLen);
+
+    // finish the new string
+    ConcatStr[LeftLen + RightLen] = 0;
+
+    // return
+    return TStr::WrapCStr(ConcatStr);
+  }
+}
+
+TStr operator+(const TStr& LStr, const TStr& RStr) {
+  return operator+(LStr, RStr.CStr());
+}
+
+TStr operator+(const TStr& LStr, const char Ch) {
+  const size_t LeftLen = LStr.Len();
+  const size_t RightLen = 1;
+
+  // check if any of the strings are empty
+  if (LeftLen == 0) { return TStr(Ch); }
+  else if (RightLen == 0) { return LStr; }
+  else {
+    const char* LCStr = LStr.CStr();
+
+    // allocate memory
+    char* ConcatStr = new char[LeftLen + RightLen + 1];
+
+    // copy the two strings into the new memory
+    memcpy(ConcatStr, LCStr, LeftLen);
+    memcpy(ConcatStr + LeftLen, &Ch, RightLen);
+
+    // finish the new string
+    ConcatStr[LeftLen + RightLen] = 0;
+
+    // return
+    return TStr::WrapCStr(ConcatStr);
+  }
+}
+
+TStr TStr::Base64Encode(const void* Bf, const int BfL) {
+  TStr ret;
+  int i = 0;
+  int j = 0;
+  unsigned char char_array_3[3];
+  unsigned char char_array_4[4];
+  int BfLTmp = BfL;
+  const uchar* BfTmp = (uchar*)Bf;
+  while (BfLTmp--) {
+    char_array_3[i++] = *(BfTmp++);
+    if (i == 3) {
+      char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
+      char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
+      char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+      char_array_4[3] = char_array_3[2] & 0x3f;
+
+      for (i = 0; (i <4); i++)
+        ret += base64_chars[char_array_4[i]];
+      i = 0;
     }
   }
-  if ((0<=Spaces)&&(Spaces<SpaceStrV.Len())){
-    return SpaceStrV[Spaces];
-  } else {
-    TChA SpaceChA;
-    for (int ChN=0; ChN<Spaces; ChN++){SpaceChA+=' ';}
-    return SpaceChA;
+
+  if (i) {
+    for (j = i; j < 3; j++) {
+      char_array_3[j] = '\0';
+    }
+    char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
+    char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
+    char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+    char_array_4[3] = char_array_3[2] & 0x3f;
+
+    for (j = 0; (j < i + 1); j++) {
+      ret += base64_chars[char_array_4[j]];
+    }
+    while ((i++ < 3)) {
+      ret += '=';
+    }
+  }
+  return ret;
+}
+
+const TStr TStr::base64_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+void TStr::Base64Decode(const TStr& In, TMem& Mem) {
+  int in_len = In.Len();
+  int i = 0;
+  int j = 0;
+  int in_ = 0;
+  unsigned char char_array_4[4], char_array_3[3];
+  Mem.Reserve(In.Len());
+  while (in_len-- && (In[in_] != '=') && is_base64(In[in_])) {
+    char_array_4[i++] = In[in_];
+    in_++;
+    if (i == 4) {
+      for (i = 0; i < 4; i++) {
+        char_array_4[i] = (uchar)base64_chars.SearchCh(char_array_4[i]);
+      }
+      char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+      char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+      char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+      Mem.AddBf(&char_array_3, 3);
+      //for (i = 0; (i < 3); i++) {
+      //  Mem.AddBf(&char_array_3[i], 1);
+      //}
+      i = 0;
+    }
+  }
+
+  if (i) {
+    for (j = i; j < 4; j++) {
+      char_array_4[j] = 0;
+    }
+    for (j = 0; j < 4; j++) {
+      char_array_4[j] = (uchar)base64_chars.SearchCh(char_array_4[j]);
+    }
+    char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+    char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+    char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+    for (j = 0; (j < i - 1); j++) {
+      Mem.AddBf(&char_array_3[j], 1);
+    }
   }
 }
 
-TStr TStr::GetNullStr(){
-  static TStr NullStr="";
-  return NullStr;
+bool TStr::IsUInt(TChRet& Ch, const bool& Check, const uint& MnVal, const uint& MxVal, uint& Val) {
+  uint64 _Val;
+  // assign and check for overflow
+  return IsUInt64(Ch, Check, MnVal, MxVal, _Val) && (uint64)(Val = (uint)_Val) == _Val;
 }
 
-TStr operator+(const TStr& LStr, const TStr& RStr){
-  if (LStr.Empty()){return RStr;}
-  else if (RStr.Empty()){return LStr;}
-  else {return TStr(LStr)+=RStr;}
+bool TStr::IsUInt64(TChRet& Ch, const bool& Check, const uint64& MnVal, const uint64& MxVal, uint64& Val) {
+  EAssert(!Check || (Check && MnVal <= MxVal));
+
+  uint64 _Val=0;
+  while (TCh::IsWs(Ch())) {
+    Ch.GetCh();
+  }
+
+  if (Ch()=='+'){Ch.GetCh();}
+  if (!TCh::IsNum(Ch())){return false;}
+  _Val=TCh::GetNum(Ch());
+
+  const uint64 MxBy10 = Check ? MxVal / 10 : TUInt64::Mx / 10;
+  const uint64 MxBy10Rem = Check ? MxVal % 10 : TUInt64::Mx % 10;
+
+  uint ChNum;
+  while (TCh::IsNum(Ch.GetCh())) {
+    ChNum = TCh::GetNum(Ch());
+
+    // check for overflow
+    if (_Val > MxBy10 || (_Val == MxBy10 && ChNum > MxBy10Rem)) {
+      return false;
+    }
+
+    // increase the sum
+    _Val = 10*_Val + ChNum;
+  }
+
+  if (Check && _Val < MnVal){return false;}
+  if (Ch.Eof()){Val=_Val; return true;} else {return false;}
 }
 
-TStr operator+(const TStr& LStr, const char* RCStr){
-  return TStr(LStr)+=RCStr;
-}
+
 
 /////////////////////////////////////////////////
 // Input-String
-TStrIn::TStrIn(const TStr& _Str):
-  TSBase("Input-String"), TSIn("Input-String"), Str(_Str), Bf(Str.CStr()), BfC(0), BfL(Str.Len()){}
+TStrIn::TStrIn(const TStr& _Str, const bool& MakeCopyP) :
+  TSBase("Input-String"), TSIn("Input-String"), OwnP(MakeCopyP),
+  Bf(MakeCopyP ? _Str.CloneCStr() : _Str.CStr()), BfC(0), BfL(_Str.Len()){}
+
+PSIn TStrIn::New(const TStr& Str, const bool& MakeCopyP){
+  return PSIn(new TStrIn(Str, MakeCopyP));
+}
 
 int TStrIn::GetBf(const void* LBf, const TSize& LBfL){
   Assert(TSize(BfC+LBfL)<=TSize(BfL));
@@ -1655,6 +2150,10 @@ bool TStrIn::GetNextLnBf(TChA& LnChA){
   // not implemented
   FailR(TStr::Fmt("TStrIn::GetNextLnBf: not implemented").CStr());
   return false;
+}
+
+TStr TStrIn::GetSNm() const {
+  return "Input-String";
 }
 
 /////////////////////////////////////////////////
@@ -1750,14 +2249,14 @@ TStrPool64::TStrPool64(::TSize _MxBfL, ::TSize _GrowBy):
   AddStr("");
 }
 
-TStrPool64::TStrPool64(const TStrPool64& StrPool): 
+TStrPool64::TStrPool64(const TStrPool64& StrPool):
   MxBfL(StrPool.MxBfL), BfL(StrPool.BfL), GrowBy(StrPool.GrowBy) {
   if (Bf != NULL) { free(Bf); } else { IAssert(MxBfL == 0); }
-  Bf = (char*)malloc(StrPool.MxBfL); IAssert(Bf != NULL); 
+  Bf = (char*)malloc(StrPool.MxBfL); IAssert(Bf != NULL);
   memcpy(Bf, StrPool.Bf, BfL);
 }
 
-TStrPool64::TStrPool64(TSIn& SIn, bool LoadCompact): 
+TStrPool64::TStrPool64(TSIn& SIn, bool LoadCompact):
   MxBfL(0), BfL(0), GrowBy(0), Bf(0) {
   uint64 _GrowBy, _MxBfL, _BfL;
   SIn.Load(_GrowBy); SIn.Load(_MxBfL); SIn.Load(_BfL);
@@ -1779,18 +2278,18 @@ TStrPool64& TStrPool64::operator=(const TStrPool64& StrPool) {
   if (this != &StrPool) {
   GrowBy = StrPool.GrowBy;  MxBfL = StrPool.MxBfL;  BfL = StrPool.BfL;
   if (Bf != NULL) { free(Bf); } else { IAssert(MxBfL == 0); }
-  Bf = (char*)malloc(MxBfL); IAssert(Bf != NULL); 
+  Bf = (char*)malloc(MxBfL); IAssert(Bf != NULL);
   memcpy(Bf, StrPool.Bf, BfL);
   }
   return *this;
 }
 
-void TStrPool64::Clr(bool DoDel) { 
-  BfL = 0; 
-  if (DoDel && (Bf!=NULL)) { 
-    free(Bf); 
-    Bf = NULL; MxBfL = 0; 
-  } 
+void TStrPool64::Clr(bool DoDel) {
+  BfL = 0;
+  if (DoDel && (Bf!=NULL)) {
+    free(Bf);
+    Bf = NULL; MxBfL = 0;
+  }
 }
 
 uint64 TStrPool64::AddStr(const TStr& Str) {
@@ -2128,7 +2627,7 @@ bool TUInt::IsIpv6Str(const TStr& IpStr, const char& SplitCh) {
 	for (int IpStrN = 0; IpStrN < IpStrV.Len(); IpStrN++) {
 		if (IpStrV[IpStrN].Empty()) { continue; }
 		if (IpStrV[IpStrN].IsHexInt(true, 0x0000, 0xFFFF, Group)) { continue; }
-		return false; 
+		return false;
 	}
 	// all fine
 	return true;

--- a/glib-core/dt.h
+++ b/glib-core/dt.h
@@ -621,7 +621,7 @@ public:
   bool IsInt(const bool& Check, const int& MnVal, const int& MxVal, int& Val) const;
   bool IsInt(int& Val) const {return IsInt(false, 0, 0, Val);}
   bool IsInt() const {int Val; return IsInt(false, 0, 0, Val);}
-  int GetInt() const {int Val; IAssertR(IsInt(false, 0, 0, Val), *this); return Val;}
+  int GetInt() const {int Val=0; IAssertR(IsInt(false, 0, 0, Val), *this); return Val;}
   int GetInt(const int& DfVal) const {
     int Val; if (IsInt(false, 0, 0, Val)){return Val;} else {return DfVal;}}
 

--- a/glib-core/dt.h
+++ b/glib-core/dt.h
@@ -311,7 +311,7 @@ public:
 
   static void LoadTxt(const PSIn& SIn, TChA& ChA);
   void SaveTxt(const PSOut& SOut) const;
-  
+
   //friend TChA operator+(const TChA& LStr, const TChA& RStr);
   //friend TChA operator+(const TChA& LStr, const TStr& RStr);
   //friend TChA operator+(const TChA& LStr, const char* RCStr);
@@ -342,253 +342,299 @@ public:
 };
 
 /////////////////////////////////////////////////
-// Ref-String
-class TRStr{
-public:
-  char* Bf;
-  int Refs;
-public:
-  TRStr(){Refs=1; Bf=new char[0+1]; Bf[0]=0;}
-  TRStr(const int& Len){
-    IAssert(Len>=0); Refs=0; Bf=new char[Len+1]; Bf[Len]=0;}
-  TRStr(const char* CStr){
-    Refs=0; Bf=new char[strlen(CStr)+1]; strcpy(Bf, CStr);}
-  TRStr(const char* CStr, const int& MxLen){
-    Refs=0; Bf=new char[MxLen+1]; strncpy(Bf, CStr, MxLen); Bf[MxLen]=0;}
-  TRStr(const char* CStr1, const char* CStr2){
-    Refs=0; int CStr1Len=int(strlen(CStr1)); Bf=new char[CStr1Len+int(strlen(CStr2))+1];
-    strcpy(Bf, CStr1); strcpy(Bf+CStr1Len, CStr2);}
-  TRStr(const char& Ch){
-    Refs=0; Bf=new char[1+1]; Bf[0]=Ch; Bf[1]=0;}
-  TRStr(const char& Ch1, const char& Ch2){
-    Refs=0; Bf=new char[2+1]; Bf[0]=Ch1; Bf[1]=Ch2; Bf[2]=0;}
-  ~TRStr(){
-    Assert(((this!=GetNullRStr())&&(Refs==0))||((this==GetNullRStr())&&(Refs==1)));
-    delete[] Bf;}
-  explicit TRStr(TSIn& SIn, const bool& IsSmall){
-    if (IsSmall){Refs=0; SIn.Load(Bf);}
-    else {Refs=0; int BfL; SIn.Load(BfL); SIn.Load(Bf, BfL, BfL);}}
-  void Save(TSOut& SOut, const bool& IsSmall) const {
-    if (IsSmall){SOut.Save(Bf);}
-    else {int BfL=int(strlen(Bf)); SOut.Save(BfL); SOut.Save(Bf, BfL);}}
+/// String.
+/// operation.
+///
+/// Operations that modify string content are not thread safe. If multiple
+/// threads might write to the same string, access needs to be serialized
+/// via locks. A single writer and multiple readers also require locking.
+/// There is no need to lock multiple read operations in multithreaded
+/// environments.
+///
+/// Small example:
+///     int main() {
+///         TStr Str0("abc");  // char* constructor
+///         Str Str1("def");   // char* constructor
+///         TStr Str2 = Str1;  // copy constructor
+///         Str2 = Str0;       // copy assignment
+///         TStr& Str3 = Str2; // no copying
+///         Str0, Str and Str2 call destructors, Str3 doesnt call destructor (that's as it should be)
+///         return 0;
+///     }
 
-  TRStr& operator=(const TRStr&){Fail; return *this;}
-  int GetMemUsed() const {return int(sizeof(int))+int(strlen(Bf));}
-
-  void MkRef(){Refs++;}
-  void UnRef(){Assert(Refs>0); if (--Refs==0){delete this;}}
-
-  const char* CStr() const {return Bf;}
-  char* CStr() {return Bf;}
-  bool Empty() const {return Bf[0]==0;}
-  int Len() const {return int(strlen(Bf));}
-
-  void PutCh(const int& ChN, const char& Ch){
-    Assert((0<=ChN)&&(ChN<Len())); Bf[ChN]=Ch;}
-  char GetCh(const int& ChN) const {
-    Assert((0<=ChN)&&(ChN<Len())); return Bf[ChN];}
-
-  bool IsUc() const;
-  void ToUc();
-  bool IsLc() const;
-  void ToLc();
-  void ToCap();
-  void ConvUsFromYuAscii();
-  static int CmpI(const char* CStr1, const char* CStr2);
-
-  int GetPrimHashCd() const;
-  int GetSecHashCd() const;
-
-  static TRStr* GetNullRStr(){
-    static TRStr NullRStr; Assert(NullRStr.Bf!=NULL); return &NullRStr;}
-};
-
-/////////////////////////////////////////////////
-// String
 class TStr;
 template <class TVal, class TSizeTy> class TVec;
 typedef TVec<TStr, int> TStrV;
 
 class TStr{
-private:
-  TRStr* RStr;
-private:
-  TStr(const char& Ch, bool){
-    RStr=new TRStr(Ch); RStr->MkRef();}
-  TStr(const char& Ch1, const char& Ch2, bool){
-    RStr=new TRStr(Ch1, Ch2); RStr->MkRef();}
-  static TRStr* GetRStr(const char* CStr);
-  void Optimize();
 public:
-  TStr(){RStr=TRStr::GetNullRStr(); RStr->MkRef();}
-  TStr(const TStr& Str){RStr=Str.RStr; RStr->MkRef();}
-  TStr(const TChA& ChA){RStr=GetRStr(ChA.CStr()); RStr->MkRef();}
-  TStr(const TSStr& SStr){RStr=GetRStr(SStr.CStr()); RStr->MkRef();}
-  TStr(const char* CStr){RStr=GetRStr(CStr); RStr->MkRef();}
-  explicit TStr(const char& Ch){RStr=GetChStr(Ch).RStr; RStr->MkRef();}
-  TStr(const TMem& Mem){
-    RStr=new TRStr(Mem.Len()); RStr->MkRef();
-    memcpy(CStr(), Mem(), Mem.Len()); Optimize();}
-  explicit TStr(const PSIn& SIn){
-    int SInLen=SIn->Len(); RStr=new TRStr(SInLen); RStr->MkRef();
-    SIn->GetBf(CStr(), SInLen); Optimize();}
-  ~TStr(){RStr->UnRef();}
-  explicit TStr(TSIn& SIn, const bool& IsSmall=false):
-    RStr(new TRStr(SIn, IsSmall)){RStr->MkRef(); Optimize();}
-  void Load(TSIn& SIn, const bool& IsSmall=false){
-    *this=TStr(SIn, IsSmall);}
-  void Save(TSOut& SOut, const bool& IsSmall=false) const {
-    RStr->Save(SOut, IsSmall);}
+  typedef const char* TIter;  //!< Random access iterator.
+private:
+  /// Used to construct empty strings ("") to be returned by CStr()
+  const static char EmptyStr;
+  /// String
+  char* Inner;
+
+  /// Wraps the char pointer with a new string. The char pointer is NOT
+  /// copied and the new string becomes responsible for deleting it.
+  static TStr WrapCStr(char* CStr);
+
+public:
+  /// Empty String Constructor
+  TStr(): Inner(nullptr) {}
+  /// C-String constructor
+  TStr(const char* CStr);
+  /// 1 char constructor
+  explicit TStr(const char& Ch);
+  /// copy constructor
+  TStr(const TStr& Str);
+  /// move constructor
+  TStr(TStr&& Str);
+  /// TChA constructor (char-array class)
+  TStr(const TChA& ChA);
+  /// TMem constructor
+  TStr(const TMem& Mem);
+  /// TSStr constructor
+  TStr(const TSStr& SStr); // KILL
+  /// Stream (file) reading constructor
+  explicit TStr(const PSIn& SIn);
+
+  /// We only delete when not empty
+  ~TStr() { Clr(); }
+
+  /// Returns an iterator pointing to the first element in the string.
+  TIter BegI() const { return Empty() ? &EmptyStr : Inner; }
+  /// Returns an iterator pointing to the first element in the string (used by C++11)
+  TIter begin() const { return Empty() ? &EmptyStr : Inner; }
+  /// Returns an iterator referring to the past-the-end element in the string.
+  TIter EndI() const { return Empty() ? &EmptyStr : Inner + Len(); }
+  /// Returns an iterator referring to the past-the-end element in the string (used by C++11))
+  TIter end() const { return Empty() ? &EmptyStr : Inner + Len(); }
+  /// Returns an iterator an element at position \c ValN.
+  TIter GetI(const int ValN) const { return Empty() ? &EmptyStr : Inner + ValN; }
+
+  /// Deserialize TStr from stream, when IsSmall, the string is saved as CStr,
+  /// otherwise the format is first the length and then the data including last \0
+  explicit TStr(TSIn& SIn, const bool& IsSmall = false);
+  // Left for compatibility reasons, best if we can remove it at some point
+  void Load(TSIn& SIn, const bool& IsSmall = false);
+  /// Serialize TStr to stream, when IsSmall, the string is saved as CStr,
+  /// otherwise the format is first the length and then the data including last \0
+  void Save(TSOut& SOut, const bool& IsSmall = false) const;
+   /// Deserialize from XML File
   void LoadXml(const PXmlTok& XmlTok, const TStr& Nm);
+  /// Serialize to XML File
   void SaveXml(TSOut& SOut, const TStr& Nm) const;
 
-  TStr& operator=(const TStr& Str){
-    if (this!=&Str){RStr->UnRef(); RStr=Str.RStr; RStr->MkRef();} return *this;}
-  TStr& operator=(const TChA& ChA){
-    RStr->UnRef(); RStr=GetRStr(ChA.CStr()); RStr->MkRef(); return *this;}
-  TStr& operator=(const char* CStr){
-    RStr->UnRef(); RStr=GetRStr(CStr); RStr->MkRef(); return *this;}
-  TStr& operator=(const char& Ch){
-    RStr->UnRef(); RStr=GetChStr(Ch).RStr; RStr->MkRef(); return *this;}
-  TStr& operator+=(const TStr& Str){
-    TRStr* NewRStr=new TRStr(RStr->CStr(), Str.RStr->CStr());
-    RStr->UnRef(); RStr=NewRStr; RStr->MkRef();
-    Optimize(); return *this;}
-  TStr& operator+=(const char* CStr){
-    TRStr* NewRStr=new TRStr(RStr->CStr(), CStr);
-    RStr->UnRef(); RStr=NewRStr; RStr->MkRef();
-    Optimize(); return *this;}
-  bool operator==(const TStr& Str) const {
-    return (RStr==Str.RStr)||(strcmp(RStr->CStr(), Str.RStr->CStr())==0);}
-  bool operator==(const char* CStr) const {
-    return strcmp(RStr->CStr(), CStr)==0;}
-//  bool operator!=(const TStr& Str) const {
-//    return strcmp(RStr->CStr(), Str.RStr->CStr())!=0;}
-  bool operator!=(const char* CStr) const {
-    return strcmp(RStr->CStr(), CStr)!=0;}
-  bool operator<(const TStr& Str) const {
-    return strcmp(RStr->CStr(), Str.RStr->CStr())<0;}
-  char operator[](const int& ChN) const {return RStr->GetCh(ChN);}
-  int GetMemUsed() const {return int(sizeof(TRStr*)+RStr->GetMemUsed());}
+  /// Assigment operator TStr = TStr
+  TStr& operator=(const TStr& Str);
+  /// Move assigment operator TStr = TStr
+  TStr& operator=(TStr&& Str);
+  /// Assigment operator TStr = TChA
+  TStr& operator=(const TChA& ChA);
+  /// Assigment operator TStr = char* (C-String)
+  TStr& operator=(const char* CStr);
 
-  char* operator()(){return RStr->CStr();}
-  const char* operator()() const {return RStr->CStr();}
-  char* CStr() {return RStr->CStr();}
-  const char* CStr() const {return RStr->CStr();}
+  /// Concatenates and assigns (not thread safe)
+  TStr& operator+=(const TStr& Str) { *this = (*this + Str); return *this; } ;
+  /// Concatenates and assigns (not thread safe)
+  TStr& operator+=(const char* _CStr) { *this = (*this + _CStr); return *this; } ;
+  /// Concatenates and assigns (not thread safe)
+  TStr& operator+=(const char Ch) { *this = (*this + Ch); return *this; };
 
-  void PutCh(const int& ChN, const char& Ch){
-    TRStr* NewRStr=new TRStr(RStr->CStr());
-    RStr->UnRef(); RStr=NewRStr; RStr->MkRef();
-    RStr->PutCh(ChN, Ch); Optimize();}
-  char GetCh(const int& ChN) const {return RStr->GetCh(ChN);}
+  /// Boolean comparison TStr == char*
+  bool operator==(const char* _CStr) const;
+  /// Boolean comparison TStr == TStr
+  bool operator==(const TStr& Str) const { return operator==(Str.CStr()); }
+  // TStr != TStr
+  bool operator!=(const TStr& Str) const { return !operator==(Str); }
+  // TStr != C-String
+  bool operator!=(const char* CStr) const { return !operator==(CStr); }
+  /// < (is less than comparison) TStr < TStr
+  bool operator<(const TStr& Str) const;
+
+  /// Indexing operator, returns character at position ChN
+  char operator[](const int& ChN) const { return GetCh(ChN); }
+  /// Indexing operator, returns character at position ChN by reference
+  char& operator[](const int& ChN);
+
+  /// Get the inner C-String
+  const char* CStr() const { return Empty() ? &EmptyStr : Inner; }
+  /// Return a COPY of the string as a C String (char array)
+  char* CloneCStr() const;
+  /// Set character to given value (not thread safe)
+  void PutCh(const int& ChN, const char& Ch);
+  /// Get character at position ChN
+  char GetCh(const int& ChN) const;
+  /// Get last character in string (before null terminator)
   char LastCh() const {return GetCh(Len()-1);}
+  /// Get String Length (null terminator not included)
+  int Len() const { return Empty() ? 0 : (int)strlen(Inner); }
+  /// Check if this is an empty string
+  bool Empty() const;
+  /// Deletes the char pointer if it is not nullptr. (not thread safe)
+  void Clr();
+  /// returns a reference to this string
+  const TStr& GetStr() const { return *this; }
+  /// Memory used by this String object
+  int GetMemUsed() const;
 
-  void Clr(){RStr->UnRef(); RStr=TRStr::GetNullRStr(); RStr->MkRef();}
-  int Len() const {return RStr->Len();}
-  bool Empty() const {return RStr->Empty();}
-
-  // upper-case
-  bool IsUc() const {return RStr->IsUc();}
+  /// Case insensitive comparison
+  static int CmpI(const char* p, const char* r);
+  /// Case insensitive comparison
+  int CmpI(const TStr& Str) const {return CmpI(CStr(), Str.CStr()); }
+  /// Case insensitive equality
+  bool EqI(const TStr& Str) const {return CmpI(CStr(), Str.CStr()) == 0; }
+  /// Is upper-case?
+  bool IsUc() const;
+  /// Converts this string to all uppercase (not thread safe)
   TStr& ToUc();
-  TStr GetUc() const {return TStr(*this).ToUc();}
-  int CmpI(const TStr& Str) const {return TRStr::CmpI(CStr(), Str.CStr());}
-  bool EqI(const TStr& Str) const {return TRStr::CmpI(CStr(), Str.CStr())==0;}
-  // lower-case
-  bool IsLc() const {return RStr->IsLc();}
+  /// Returns a new string converted to uppercase
+  TStr GetUc() const;
+  /// Is lower-case?
+  bool IsLc() const;
+  /// Converts this string to all lowercase (not thread safe)
   TStr& ToLc();
-  TStr GetLc() const {return TStr(*this).ToLc();}
-  // capitalize
+  /// Returns new string converted to lowercase
+  TStr GetLc() const;
+  /// Converts this string to capitalized (first char is uppercase, rest lowercase) (not thread safe)
   TStr& ToCap();
-  TStr GetCap() const {return TStr(*this).ToCap();}
+  /// Returns string as capitalized (first char is uppercase, rest lowercase)
+  TStr GetCap() const;
 
-  // truncate
+  /// Replaces string with truncated (remove whitespace at start and end) (not thread safe)
   TStr& ToTrunc();
-  TStr GetTrunc() const {return TStr(*this).ToTrunc();}
-  // Yu-Ascii to Us-Ascii
-  TStr& ConvUsFromYuAscii();
-  TStr GetUsFromYuAscii() const {return TStr(*this).ConvUsFromYuAscii();}
-  // hex
+  /// Returns truncated string (remove whitespace at start and end)
+  TStr GetTrunc() const;
+  /// Replaces each char with two chars with its hex-code (not thread safe)
   TStr& ToHex();
-  TStr GetHex() const {return TStr(*this).ToHex();}
+  /// Get string with each char replaced with two chars with its hex-code
+  TStr GetHex() const;
+  /// Does inverse of ToHex (not thread safe)
   TStr& FromHex();
-  TStr GetFromHex() const {return TStr(*this).FromHex();}
+  /// Does inverse of GetHex
+  TStr GetFromHex() const;
 
+  /// Get substring from in interval [BchN, EchN]
   TStr GetSubStr(const int& BChN, const int& EChN) const;
+  /// Get substring from BchN (includive) to the end of the string
   TStr GetSubStr(const int& BChN) const { return GetSubStr(BChN, Len()-1); }
+  /// safe version for getting substring from BchN to EchN
+  TStr GetSubStrSafe(const int& BChN, const int& EChN) const;
+  /// safe version for getting substring from BchN to EchN
+  TStr GetSubStrSafe(const int& BChN) const { return GetSubStrSafe(BChN, Len() - 1); }
+  /// Insert a string Str into this string starting position BchN (not thread safe)
   void InsStr(const int& BChN, const TStr& Str);
+  /// Delete all the occurrences of char Ch (not thread safe)
   void DelChAll(const char& Ch);
+  /// Delete substring from BChN to EChN (not thread safe)
   void DelSubStr(const int& BChN, const int& EChN);
+  /// Delete first occurrences of substring Str (not thread safe)
   bool DelStr(const TStr& Str);
+  /// Delete all occurrences of substring Str (single pass) (not thread safe)
+  int DelStrAll(const TStr& Str);
+
+  /// Get substring from beginning till the character before first occurrence of SplitCh
   TStr LeftOf(const char& SplitCh) const;
+  /// Get substring from beginning till the character before last occurrence of SplitCh
   TStr LeftOfLast(const char& SplitCh) const;
+  /// Get substring from the character after first occurrence of SplitCh till the end
   TStr RightOf(const char& SplitCh) const;
+  /// Get substring from the character after last occurrence of SplitCh till the end
   TStr RightOfLast(const char& SplitCh) const;
+  /// Remove the StartStr if it occurs at the beginning of the string
+  TStr TrimLeft(const TStr& StartStr) const { return StartsWith(StartStr) ? GetSubStrSafe(StartStr.Len()) : TStr(*this); }
+  /// Remove the EndStr if it occurs at the end of the string
+  TStr TrimRight(const TStr& EndStr) const { return EndsWith(EndStr) ? GetSubStrSafe(0, Len() - EndStr.Len() - 1) : TStr(*this); }
+
+  /// Puts the contents to the left of LeftOfChN (exclusive) into LStr and the
+  /// contents on the right of RightOfChN into RStr (exclusive)
+  void SplitLeftOfRightOf(TStr& LStr, const int& LeftOfChN, const int& RightOfChN, TStr& RStr) const;
+  /// Split on the index, return Pair of Left/Right strings, omits the target index
+  void SplitOnChN(TStr& LStr, const int& ChN, TStr& RStr) const;
+  /// Split on first occurrence of SplitCh, return Pair of Left/Right strings, omits the target character
+  /// if the character is not found the whole string is returned as the left side
   void SplitOnCh(TStr& LStr, const char& SplitCh, TStr& RStr) const;
+  /// Splits on the first occurrence of the target string
+  /// if the target string is not found the whole string is returned as the left side
+  void SplitOnStr(TStr& LStr, const TStr& SplitStr, TStr& RStr) const;
+  /// Split on last occurrence of SplitCh, return Pair of Left/Right strings
+  /// if the character is not found the whole string is returned as the right side
   void SplitOnLastCh(TStr& LStr, const char& SplitCh, TStr& RStr) const;
-  void SplitOnAllCh(
-   const char& SplitCh, TStrV& StrV, const bool& SkipEmpty=true) const;
-  void SplitOnAllAnyCh(
-   const TStr& SplitChStr, TStrV& StrV, const bool& SkipEmpty=true) const;
+  /// Split on all occurrences of SplitCh, write to StrV, optionally don't create empy strings (default true)
+  void SplitOnAllCh(const char& SplitCh, TStrV& StrV, const bool& SkipEmpty=true) const;
+  /// Split on all occurrences of any char in SplitChStr, optionally don't create empy strings (default true)
+  void SplitOnAllAnyCh(const TStr& SplitChStr, TStrV& StrV, const bool& SkipEmpty=true) const;
+  /// Split on the occurrences of any string in StrV
   void SplitOnWs(TStrV& StrV) const;
+  /// Split on the occurrences of any non alphanumeric character
   void SplitOnNonAlNum(TStrV& StrV) const;
+  /// Split on all the occurrences of SplitStr, doesn't remove the split string (splitting aabbaacc on aa results in aa, bbaa, cc
   void SplitOnStr(const TStr& SplitStr, TStrV& StrV) const;
-  void SplitOnStr(TStr& LeftStr, const TStr& MidStr, TStr& RightStr) const;
 
-  //TStr Left(const int& Chs) const { return Chs>0 ? GetSubStr(0, Chs-1) : GetSubStr(0, Len()-Chs-1);}
-  //TStr Right(const int& Chs) const {return GetSubStr(Len()-Chs, Len()-1);}
-  TStr Mid(const int& BChN, const int& Chs) const { return GetSubStr(BChN, BChN+Chs-1); }
-  TStr Mid(const int& BChN) const {return GetSubStr(BChN, Len()-1); }
-  //TStr Slice(const int& BChN, const int& EChNP1) const {return GetSubStr(BChN, EChNP1-1);}
-  //TStr operator()(const int& BChN, const int& EChNP1) const {return Slice(BChN, EChNP1);}
-  //J: as in python or matlab: position 1 is 1st character, -1 is last character
-  TStr Left(const int& EChN) const { return EChN>0 ? GetSubStr(0, EChN-1) : GetSubStr(0, Len()+EChN-1);}
+  /// Get substring from beginning till character positioned at EChN (exclusive).
+  /// In case EChN is negative, it counts from the back of the string.
+  TStr Left(const int& EChN) const;
+  /// Get substring from character positioned at BChN (inclusive) till the end.
+  /// In case BChN is negative, it counts from the back of the string.
   TStr Right(const int& BChN) const {return BChN>=0 ? GetSubStr(BChN, Len()-1) : GetSubStr(Len()+BChN, Len()-1);}
-  TStr Slice(int BChN, int EChNP1) const { if(BChN<0){BChN=Len()+BChN;} if(EChNP1<=0){EChNP1=Len()+EChNP1;} return GetSubStr(BChN, EChNP1-1); }
-  TStr operator()(const int& BChN, const int& EChNP1) const {return Slice(BChN, EChNP1);}
 
+  /// Counts occurrences of a character between [BChN, end]
   int CountCh(const char& Ch, const int& BChN=0) const;
+  /// Returns the position of the first occurrence of a character between [BChN, end]
   int SearchCh(const char& Ch, const int& BChN=0) const;
+  /// Returns the position of the last occurrence of a character between [BChN, end]
   int SearchChBack(const char& Ch, int BChN=-1) const;
+  /// Returns the position of the first occurrence of a (sub)string between [BChN, end]
   int SearchStr(const TStr& Str, const int& BChN=0) const;
+  /// Returns true if character occurs in string
   bool IsChIn(const char& Ch) const {return SearchCh(Ch)!=-1;}
+  /// Returns true if (sub)string occurs in string
   bool IsStrIn(const TStr& Str) const {return SearchStr(Str)!=-1;}
-  bool IsPrefix(const char *Str) const;
-  bool IsPrefix(const TStr& Str) const {
-    return IsPrefix(Str.CStr());}
-  bool IsSuffix(const char *Str) const;
-  bool IsSuffix(const TStr& Str) const {
-    return IsSuffix(Str.CStr());}
+  /// Returns true if this string starts with the prefix c-string
+  bool StartsWith(const char *Str) const;
+  /// Returns true if this string starts with the prefix string
+  bool StartsWith(const TStr& Str) const { return StartsWith(Str.CStr()); }
+  /// Returns true if this string ends with the sufix c-string
+  bool EndsWith(const char *Str) const;
+  /// Returns true if this string ends with the sufix string
+  bool EndsWith(const TStr& Str) const { return EndsWith(Str.CStr()); }
 
+  /// Replaces first occurrence of SrcCh character with DstCh. Start search at BChN. (not thread safe)
   int ChangeCh(const char& SrcCh, const char& DstCh, const int& BChN=0);
+  /// Replaces all occurrences of SrcCh character with DstCh (not thread safe)
   int ChangeChAll(const char& SrcCh, const char& DstCh);
+  /// Replace first occurrence of ScrStr string with DstStr string. Start search at BChN. (not thread safe)
   int ChangeStr(const TStr& SrcStr, const TStr& DstStr, const int& BChN=0);
-  int ChangeStrAll(const TStr& SrcStr, const TStr& DstStr, const bool& FromStartP=false);
-  TStr Reverse() const {
-    TChA ChA(*this); ChA.Reverse(); return ChA;}
+  /// Replace all occurrences of ScrStr string with DstStr string (not thread safe)
+  int ChangeStrAll(const TStr& SrcStr, const TStr& DstStr);
+  /// Returns a String with the order of the characters in this String Reversed
+  TStr Reverse() const;
 
-  int GetPrimHashCd() const {return RStr->GetPrimHashCd();}
-  int GetSecHashCd() const {return RStr->GetSecHashCd();}
+  int GetPrimHashCd() const;
+  int GetSecHashCd() const;
 
+  /// Return true if string is 'T' or 'F'. Return true or false accordingly in Val
   bool IsBool(bool& Val) const;
 
-  bool IsInt(
-   const bool& Check, const int& MnVal, const int& MxVal, int& Val) const;
+  // integer
+  bool IsInt(const bool& Check, const int& MnVal, const int& MxVal, int& Val) const;
   bool IsInt(int& Val) const {return IsInt(false, 0, 0, Val);}
   bool IsInt() const {int Val; return IsInt(false, 0, 0, Val);}
   int GetInt() const {int Val; IAssertR(IsInt(false, 0, 0, Val), *this); return Val;}
   int GetInt(const int& DfVal) const {
     int Val; if (IsInt(false, 0, 0, Val)){return Val;} else {return DfVal;}}
 
-  bool IsUInt(
-   const bool& Check, const uint& MnVal, const uint& MxVal, uint& Val) const;
+  // unsigned integer
+  bool IsUInt(const bool& Check, const uint& MnVal, const uint& MxVal, uint& Val) const;
   bool IsUInt(uint& Val) const {return IsUInt(false, 0, 0, Val);}
   bool IsUInt() const {uint Val; return IsUInt(false, 0, 0, Val);}
   uint GetUInt() const {uint Val; IAssert(IsUInt(false, 0, 0, Val)); return Val;}
   uint GetUInt(const uint& DfVal) const {
     uint Val; if (IsUInt(false, 0, 0, Val)){return Val;} else {return DfVal;}}
 
-  bool IsInt64(
-   const bool& Check, const int64& MnVal, const int64& MxVal, int64& Val) const;
+  // 64-bit integer
+  bool IsInt64(const bool& Check, const int64& MnVal, const int64& MxVal, int64& Val) const;
   bool IsInt64(int64& Val) const {return IsInt64(false, 0, 0, Val);}
   bool IsInt64() const {int64 Val; return IsInt64(false, 0, 0, Val);}
   int64 GetInt64() const {
@@ -596,8 +642,8 @@ public:
   int64 GetInt64(const int64& DfVal) const {
     int64 Val; if (IsInt64(false, 0, 0, Val)){return Val;} else {return DfVal;}}
 
-  bool IsUInt64(
-   const bool& Check, const uint64& MnVal, const uint64& MxVal, uint64& Val) const;
+  // unsigned 64-bit integer
+  bool IsUInt64(const bool& Check, const uint64& MnVal, const uint64& MxVal, uint64& Val) const;
   bool IsUInt64(uint64& Val) const {return IsUInt64(false, 0, 0, Val);}
   bool IsUInt64() const {uint64 Val; return IsUInt64(false, 0, 0, Val);}
   uint64 GetUInt64() const {
@@ -630,6 +676,9 @@ public:
   double GetFlt(const double& DfVal) const {
     double Val; if (IsFlt(false, 0, 0, Val)){return Val;} else {return DfVal;}}
 
+  /*
+   * Word matching methods
+   */
   bool IsWord(const bool& WsPrefixP=true, const bool& FirstUcAllowedP=true) const;
   bool IsWs() const;
 
@@ -644,14 +693,21 @@ public:
   bool IsWcMatch(const TStr& WcStr) const;
   TStr GetWcMatch(const TStr& WcStr, const int& StarStrN=0) const;
 
+  /*
+   * Path Handling Functions
+   */
   TStr GetFPath() const;
   TStr GetFBase() const;
   TStr GetFMid() const;
   TStr GetFExt() const;
+
+  /*
+   * Static Path Handling Functions
+   */
   static TStr GetNrFPath(const TStr& FPath);
   static TStr GetNrFMid(const TStr& FMid);
   static TStr GetNrFExt(const TStr& FExt);
-  static TStr GetNrNumFExt(const int& FExtN);
+  static TStr GetNrNumFExt(const int& FExtN, const int& MinLen = 3);
   static TStr GetNrFNm(const TStr& FNm);
   static TStr GetNrAbsFPath(const TStr& FPath, const TStr& BaseFPath=TStr());
   static bool IsAbsFPath(const TStr& FPath);
@@ -663,6 +719,9 @@ public:
   static TStr GetNumFNm(const TStr& FNm, const int& Num);
   static TStr GetFNmStr(const TStr& Str, const bool& AlNumOnlyP=true);
 
+  /*
+   * Static Save/Load Text File Functions
+   */
   static TStr LoadTxt(const PSIn& SIn){
     return TStr(SIn);}
   static TStr LoadTxt(const TStr& FNm){
@@ -672,41 +731,57 @@ public:
   void SaveTxt(const TStr& FNm) const {
     PSOut SOut=TFOut::New(FNm); SaveTxt(SOut);}
 
-  static TStr& GetChStr(const char& Ch);
-  static TStr& GetDChStr(const char& Ch1, const char& Ch2);
-
-  TStr GetStr() const {return *this;}
+  /*
+   * Static methods for FmtStr
+   */
   static TStr GetStr(const TStr& Str, const char* FmtStr);
-  static TStr GetStr(const TStr& Str, const TStr& FmtStr){
-    return GetStr(Str, FmtStr.CStr());}
+  static TStr GetStr(const TStr& Str, const TStr& FmtStr) { return GetStr(Str, FmtStr.CStr()); }
   static TStr GetStr(const TStrV& StrV, const TStr& DelimiterStr);
   static TStr Fmt(const char *FmtStr, ...);
   static TStr GetSpaceStr(const int& Spaces);
-  char* GetCStr() const {
-    char* Bf=new char[Len()+1]; strcpy(Bf, CStr()); return Bf;}
 
-  static TStr MkClone(const TStr& Str){return TStr(Str.CStr());}
-  static TStr GetNullStr();
-
-  friend TStr operator+(const TStr& LStr, const TStr& RStr);
+  /// Concatenates the first string parameter with the char array
   friend TStr operator+(const TStr& LStr, const char* RCStr);
+  /// Concatenates the two strings
+  friend TStr operator+(const TStr& LStr, const TStr& RStr);
+  /// Concatenates the first string parameter with single char
+  friend TStr operator+(const TStr& LStr, const char Ch);
+
+  /// Base64-encode given buffer and return resulting string
+  static TStr Base64Encode(const void* Bf, const int BfL);
+  /// Base64-decode given string and fill this TMem object
+  static void Base64Decode(const TStr& In, TMem& Mem);
+
+private:
+
+  /// Static mapping utility for base64 characters
+  static const TStr base64_chars;
+  /// This method checks if given character belongs to base64 range
+  static inline bool is_base64(unsigned char c) { return (isalnum(c) || (c == '+') || (c == '/')); };
+
+  /// internal method used to check if the string stored in TChRet is an unsigned integer
+  /// IMPORTANT: TChRet must be initialized (GetCh() must be called at least once)
+  static bool IsUInt(TChRet& Ch, const bool& Check, const uint& MnVal, const uint& MxVal, uint& Val);
+  /// internal method used to check if the string stored in TChRet is a 64-bit unsigned integer
+  /// IMPORTANT: TChRet must be initialized (GetCh() must be called at least once)
+  static bool IsUInt64(TChRet& Ch, const bool& Check, const uint64& MnVal, const uint64& MxVal, uint64& Val);
 };
 
 /////////////////////////////////////////////////
 // Input-String
 class TStrIn: public TSIn{
 private:
-  TStr Str;
-  char* Bf;
+  const bool OwnP;
+  const char* Bf;
   int BfC, BfL;
 private:
   TStrIn();
   TStrIn(const TStrIn&);
-  TStrIn& operator = (const TStrIn&);
+  TStrIn& operator=(const TStrIn&);
 public:
-  TStrIn(const TStr& _Str);
-  static PSIn New(const TStr& Str){return PSIn(new TStrIn(Str));}
-  ~TStrIn(){}
+  TStrIn(const TStr& Str, const bool& MakeCopyP = true);
+  static PSIn New(const TStr& Str, const bool& MakeCopyP = true);
+  ~TStrIn(){ if (OwnP) { delete[] Bf; }}
 
   bool Eof(){return BfC==BfL;}
   int Len() const {return BfL-BfC;}
@@ -715,6 +790,7 @@ public:
   int GetBf(const void* LBf, const TSize& LBfL);
   void Reset(){Cs=TCs(); BfC=0;}
   bool GetNextLnBf(TChA& LnChA);
+  TStr GetSNm() const;
 };
 
 /////////////////////////////////////////////////
@@ -807,9 +883,9 @@ public:
   uint AddStr(const TStr& Str) { return AddStr(Str.CStr(), Str.Len() + 1); }
 
   TStr GetStr(const uint& Offset) const { Assert(Offset < BfL);
-    if (Offset == 0) return TStr::GetNullStr(); else return TStr(Bf + Offset); }
+    if (Offset == 0) return TStr(); else return TStr(Bf + Offset); }
   const char *GetCStr(const uint& Offset) const { Assert(Offset < BfL);
-    if (Offset == 0) return TStr::GetNullStr().CStr(); else return Bf + Offset; }
+    if (Offset == 0) return TStr().CStr(); else return Bf + Offset; }
 
   // Clr() removes the empty string at the start.
   // Call AddStr("") after Clr(), if you want to use the pool again.
@@ -841,9 +917,9 @@ public:
   ~TStrPool64() { Clr(true); }
   void Save(TSOut& SOut) const;
 
-  static PStrPool64 New(::TSize MxBfL = 0, ::TSize GrowBy = 16*1024*1024) { 
+  static PStrPool64 New(::TSize MxBfL = 0, ::TSize GrowBy = 16*1024*1024) {
       return PStrPool64(new TStrPool64(MxBfL, GrowBy)); }
-  static PStrPool64 Load(TSIn& SIn, bool LoadCompact = true) { 
+  static PStrPool64 Load(TSIn& SIn, bool LoadCompact = true) {
       return PStrPool64(new TStrPool64(SIn, LoadCompact)); }
 
   TStrPool64& operator=(const TStrPool64& StrPool);
@@ -1658,4 +1734,3 @@ public:
   // string
   TStr GetStr() const;
 };
-

--- a/glib-core/dt.h
+++ b/glib-core/dt.h
@@ -381,7 +381,7 @@ private:
 
 public:
   /// Empty String Constructor
-  TStr(): Inner(nullptr) {}
+  TStr(): Inner(NULL) {}
   /// C-String constructor
   TStr(const char* CStr);
   /// 1 char constructor
@@ -472,7 +472,7 @@ public:
   int Len() const { return Empty() ? 0 : (int)strlen(Inner); }
   /// Check if this is an empty string
   bool Empty() const;
-  /// Deletes the char pointer if it is not nullptr. (not thread safe)
+  /// Deletes the char pointer if it is not NULL. (not thread safe)
   void Clr();
   /// returns a reference to this string
   const TStr& GetStr() const { return *this; }

--- a/glib-core/env.cpp
+++ b/glib-core/env.cpp
@@ -13,7 +13,7 @@ TEnv::TEnv(const TStr& _ArgStr, const PNotify& _Notify):
 
 TStr TEnv::GetExeFNm() const {
   TStr ExeFNm=GetArg(0);
-  if (ExeFNm.IsPrefix("//?")){ // observed on Win64 CGI
+  if (ExeFNm.StartsWith("//?")){ // observed on Win64 CGI
     ExeFNm=ExeFNm.GetSubStr(3, ExeFNm.Len());
   }
   return ExeFNm;
@@ -286,8 +286,12 @@ void TEnv::GetVarNmValV(TStrV& VarNmValV){
 }
 
 void TEnv::PutVarVal(const TStr& VarNm, const TStr& VarVal) {
-  const int RetVal = putenv(TStr::Fmt("%s=%s", VarNm.CStr(), VarVal.CStr()).CStr());
-  IAssert(RetVal==0);
+#ifdef GLib_WIN
+  const int ErrCd = _putenv(TStr::Fmt("%s=%s", VarNm.CStr(), VarVal.CStr()).CStr());
+#else
+  const int ErrCd = setenv(VarNm.CStr(), VarVal.CStr(), 1);
+#endif
+  IAssert(ErrCd==0);
 }
 
 TStr TEnv::GetVarVal(const TStr& VarNm) const {
@@ -295,4 +299,3 @@ TStr TEnv::GetVarVal(const TStr& VarNm) const {
 }
 
 TEnv Env;
-

--- a/glib-core/env.cpp
+++ b/glib-core/env.cpp
@@ -14,7 +14,7 @@ TEnv::TEnv(const TStr& _ArgStr, const PNotify& _Notify):
 TStr TEnv::GetExeFNm() const {
   TStr ExeFNm=GetArg(0);
   if (ExeFNm.StartsWith("//?")){ // observed on Win64 CGI
-    ExeFNm=ExeFNm.GetSubStr(3, ExeFNm.Len());
+    ExeFNm=ExeFNm.GetSubStr(3, ExeFNm.Len()-1);
   }
   return ExeFNm;
 }
@@ -31,7 +31,7 @@ TStr TEnv::GetCmLn(const int& FromArgN) const {
 int TEnv::GetPrefixArgN(const TStr& PrefixStr) const {
   int ArgN=0;
   while (ArgN<GetArgs()){
-    if (GetArg(ArgN).GetSubStr(0, PrefixStr.Len()-1)==PrefixStr){return ArgN;}
+    if (GetArg(ArgN).StartsWith(PrefixStr)){return ArgN;}
     ArgN++;
   }
   return -1;
@@ -40,7 +40,7 @@ int TEnv::GetPrefixArgN(const TStr& PrefixStr) const {
 TStr TEnv::GetArgPostfix(const TStr& PrefixStr) const {
   int ArgN=GetPrefixArgN(PrefixStr); IAssert(ArgN!=-1);
   TStr ArgStr=GetArg(ArgN);
-  return ArgStr.GetSubStr(PrefixStr.Len(), ArgStr.Len());
+  return ArgStr.GetSubStr(PrefixStr.Len(), ArgStr.Len()-1);
 }
 
 void TEnv::PrepArgs(const TStr& _HdStr, const int& _MnArgs, const bool& _SilentP){
@@ -155,7 +155,7 @@ TStrV TEnv::GetIfArgPrefixStrV(
       TStr ArgStr=GetArg(ArgN);
       if (ArgStr.GetSubStr(0, PrefixStr.Len()-1)==PrefixStr){
         // extract & add argument value
-        TStr ArgVal=ArgStr.GetSubStr(PrefixStr.Len(), ArgStr.Len());
+        TStr ArgVal=ArgStr.GetSubStr(PrefixStr.Len(), ArgStr.Len()-1);
         ArgValV.Add(ArgVal);
         // add to message string
         if (ArgValV.Len()>1){ArgValVChA+=", ";}

--- a/glib-core/hash.h
+++ b/glib-core/hash.h
@@ -40,6 +40,11 @@ public:
       Next=HashKeyDat.Next; HashCd=HashKeyDat.HashCd;
       Key=HashKeyDat.Key; Dat=HashKeyDat.Dat;}
     return *this;}
+  THashKeyDat& operator=(THashKeyDat&& HashKeyDat){
+    if (this!=&HashKeyDat){
+      Next=HashKeyDat.Next; HashCd=HashKeyDat.HashCd;
+      Key=std::move(HashKeyDat.Key); Dat=std::move(HashKeyDat.Dat);}
+    return *this;}
 };
 #pragma pack(pop)
 

--- a/glib-core/hash.h
+++ b/glib-core/hash.h
@@ -824,14 +824,14 @@ public:
   int64 AddStr(const TStr& Str) { return AddStr(Str.CStr(), Str.Len() + 1); }
 
   TStr GetStr(const int64& StrId) const { Assert(StrId < GetStrs());
-    if (StrId == 0) return TStr::GetNullStr(); else return TStr(Bf + (TSize)IdOffV[StrId]); }
+    if (StrId == 0) return TStr(); else return TStr(Bf + (TSize)IdOffV[StrId]); }
   const char *GetCStr(const int64& StrId) const { Assert(StrId < GetStrs());
-    if (StrId == 0) return TStr::GetNullStr().CStr(); else return (Bf + (TSize)IdOffV[StrId]); }
+    if (StrId == 0) return TStr().CStr(); else return (Bf + (TSize)IdOffV[StrId]); }
 
   TStr GetStrFromOffset(const TSize& Offset) const { Assert(Offset < BfL);
-    if (Offset == 0) return TStr::GetNullStr(); else return TStr(Bf + Offset); }
+    if (Offset == 0) return TStr(); else return TStr(Bf + Offset); }
   const char *GetCStrFromOffset(const TSize& Offset) const { Assert(Offset < BfL);
-    if (Offset == 0) return TStr::GetNullStr().CStr(); else return Bf + Offset; }
+    if (Offset == 0) return TStr().CStr(); else return Bf + Offset; }
 
   void Clr(bool DoDel = false) {
     BfL = 0; if (DoDel && Bf) {if (!IsShM) { free(Bf);} Bf = 0; MxBfL = 0;}}

--- a/glib-core/hash.h
+++ b/glib-core/hash.h
@@ -63,10 +63,14 @@ public:
     KeyDatI=HashKeyDatI.KeyDatI; EndI=HashKeyDatI.EndI; return *this;}
   bool operator==(const THashKeyDatI& HashKeyDatI) const {
     return KeyDatI==HashKeyDatI.KeyDatI;}
+  bool operator!=(const THashKeyDatI& HashKeyDatI) const {
+    return KeyDatI!=HashKeyDatI.KeyDatI;}
   bool operator<(const THashKeyDatI& HashKeyDatI) const {
     return KeyDatI<HashKeyDatI.KeyDatI;}
-  THashKeyDatI& operator++(int){ KeyDatI++; while (KeyDatI < EndI && KeyDatI->HashCd==-1) { KeyDatI++; } return *this; }
-  THashKeyDatI& operator--(int){ do { KeyDatI--; } while (KeyDatI->HashCd==-1); return *this;}
+  THashKeyDatI& operator++(){ KeyDatI++; while (KeyDatI < EndI && KeyDatI->HashCd==-1) { KeyDatI++; } return *this; }
+  THashKeyDatI& operator--(){ do { KeyDatI--; } while (KeyDatI->HashCd==-1); return *this;}
+  THashKeyDatI operator++(int){ THashKeyDatI OldVal = *this; KeyDatI++; while (KeyDatI < EndI && KeyDatI->HashCd==-1) { KeyDatI++; } return OldVal; }
+  THashKeyDatI operator--(int){ THashKeyDatI OldVal = *this; do { KeyDatI--; } while (KeyDatI->HashCd==-1); return OldVal;}
   THKeyDat& operator*() const { return *KeyDatI; }
   THKeyDat& operator()() const { return *KeyDatI; }
   THKeyDat* operator->() const { return KeyDatI; }
@@ -173,7 +177,7 @@ public:
     FreeKeys=TInt64(ShMIn);
     ShMIn.LoadCs();
   }
-  
+
   void Load(TSIn& SIn){
     PortV.Load(SIn); KeyDatV.Load(SIn);
     AutoSizeP=TBool(SIn); FFreeKeyId=TInt64(SIn); FreeKeys=TInt64(SIn);
@@ -216,6 +220,8 @@ public:
     TSizeTy FKeyId=-1;  FNextKeyId(FKeyId);
     return TIter(KeyDatV.BegI()+FKeyId, KeyDatV.EndI()); }
   TIter EndI() const {return TIter(KeyDatV.EndI(), KeyDatV.EndI());}
+  TIter begin() const { return BegI(); } // required by C++11 for each
+  TIter end() const { return EndI(); } // required by C++11 for each
   //TIter GetI(const int& KeyId) const {return TIter(&KeyDatV[KeyId], KeyDatV.EndI());}
   TIter GetI(const TKey& Key) const {return TIter(&KeyDatV[GetKeyId(Key)], KeyDatV.EndI());}
 
@@ -1318,9 +1324,9 @@ public:
   inline static int GetSecHashCd(const char *p) {
     const char *r = p;  while (*r) { r++; }
     return (int) DJBHash((const char *) p, r - p) & 0x7fffffff; }
-  inline static int GetPrimHashCd(const TStr& s) { 
+  inline static int GetPrimHashCd(const TStr& s) {
     return GetPrimHashCd(s.CStr()); }
-  inline static int GetSecHashCd(const TStr& s) { 
+  inline static int GetSecHashCd(const TStr& s) {
     return GetSecHashCd(s.CStr()); }
   inline static int GetPrimHashCd(const char *p, const ::TSize& Len) {
     return (int) DJBHash((const char *) p, Len) & 0x7fffffff; }

--- a/glib-core/http.cpp
+++ b/glib-core/http.cpp
@@ -813,9 +813,9 @@ bool THttpResp::IsFldVal(const TStr& FldNm, const TStr& FldVal) const {
 void THttpResp::AddFldVal(const TStr& FldNm, const TStr& FldVal){
   TStr NrFldNm=THttpLx::GetNrStr(FldNm);
   FldNmToValVH.AddDat(NrFldNm).Add(FldVal);
-  if (HdStr.IsSuffix("\r\n\r\n")){
+  if (HdStr.EndsWith("\r\n\r\n")){
     TChA HdChA=HdStr;
-    HdChA.Pop(); HdChA.Pop(); 
+    HdChA.Pop(); HdChA.Pop();
     HdChA+=NrFldNm; HdChA+=": "; HdChA+=FldVal;
     HdChA+="\r\n\r\n";
     HdStr=HdChA;
@@ -832,7 +832,7 @@ void THttpResp::GetCookieKeyValDmPathQuV(TStrQuV& CookieKeyValDmPathQuV){
     TStrPrV KeyValPrV; TStr DmNm; TStr PathStr;
     for (int KeyValStrN=0; KeyValStrN<KeyValStrV.Len(); KeyValStrN++){
       TStr KeyValStr=KeyValStrV[KeyValStrN];
-      TStr KeyNm; TStr ValStr; 
+      TStr KeyNm; TStr ValStr;
       if (KeyValStr.IsChIn('=')){
         KeyValStrV[KeyValStrN].SplitOnCh(KeyNm, '=', ValStr);
         KeyNm.ToTrunc(); ValStr.ToTrunc();
@@ -862,4 +862,3 @@ PSIn THttpResp::GetSIn() const {
   MOut.PutStr(HdStr); MOut.PutMem(BodyMem);
   return MOut.GetSIn();
 }
-

--- a/glib-core/shash.h
+++ b/glib-core/shash.h
@@ -1023,10 +1023,15 @@ public:
     KeyI=SetKeyI.KeyI; EndI=SetKeyI.EndI; return *this; }
   bool operator==(const THashSetKeyI& SetKeyI) const {
     return KeyI==SetKeyI.KeyI; }
+  bool operator!=(const THashSetKeyI& SetKeyI) const {
+    return KeyI!=SetKeyI.KeyI;}
   bool operator<(const THashSetKeyI& SetKeyI) const {
     return KeyI<SetKeyI.KeyI; }
-  THashSetKeyI& operator++(int) { KeyI++; while (KeyI < EndI && KeyI->HashCd==-1) { KeyI++; } return *this; }
-  THashSetKeyI& operator--(int) { do { KeyI--; } while (KeyI->HashCd==-1); return *this; }
+
+  THashSetKeyI& operator++(){ KeyI++; while (KeyI < EndI && KeyI->HashCd==-1) { KeyI++; } return *this; }
+  THashSetKeyI& operator--(){ do { KeyI--; } while (KeyI->HashCd==-1); return *this;}
+  THashSetKeyI operator++(int){ THashSetKeyI OldVal = *this; KeyI++; while (KeyI < EndI && KeyI->HashCd==-1) { KeyI++; } return OldVal; }
+  THashSetKeyI operator--(int){ THashSetKeyI OldVal = *this; do { KeyI--; } while (KeyI->HashCd==-1); return OldVal;}
 
   const TKey& operator*() const { return KeyI->Key; }
   const TKey& operator()() const { return KeyI->Key; }
@@ -1110,6 +1115,8 @@ public:
     return TIter(KeyV.EndI(), KeyV.EndI());
   }
   TIter EndI() const {return TIter(KeyV.EndI(), KeyV.EndI()); }
+  TIter begin() const { return BegI(); } // required by C++11 for each
+  TIter end() const { return EndI(); } // required by C++11 for each
   TIter GetI(const TKey& Key) const {return TIter(&KeyV[GetKeyId(Key)], KeyV.EndI()); }
 
   void Gen(const TSizeTy& ExpectVals) {

--- a/glib-core/ss.cpp
+++ b/glib-core/ss.cpp
@@ -18,10 +18,10 @@ TStr TSs::GetVal(const int& X, const int& Y) const {
     if ((0<=X)&&(X<CellStrVV[Y]->Len())){
       return CellStrVV[Y]->V[X];
     } else {
-      return TStr::GetNullStr();
+      return TStr();
     }
   } else {
-    return TStr::GetNullStr();
+    return TStr();
   }
 }
 

--- a/glib-core/tm.cpp
+++ b/glib-core/tm.cpp
@@ -125,7 +125,7 @@ TStr TTmInfo::GetTmUnitStr(const TTmUnit& TmUnit) {
     case tmuEdges : return "Edges";
     default: Fail;
   }
-  return TStr::GetNullStr();
+  return TStr();
 }
 
 TStr TTmInfo::GetTmZoneDiffStr(const TStr& TmZoneStr){
@@ -1089,13 +1089,13 @@ uint64 TTm::GetPerfTimerTicks(){
   return TSysTm::GetPerfTimerTicks();
 }
 
-void TTm::GetDiff(const TTm& Tm1, const TTm& Tm2, int& Days, 
+void TTm::GetDiff(const TTm& Tm1, const TTm& Tm2, int& Days,
 	  int& Hours, int& Mins, int& Secs, int& MSecs) {
 
 	const uint64 DiffMSecs = TTm::GetDiffMSecs(Tm1, Tm2);
 	const uint64 DiffSecs = DiffMSecs / 1000;
 	const uint64 DiffMins = DiffSecs / 60;
-	const uint64 DiffHours = DiffMins / 60;	
+	const uint64 DiffHours = DiffMins / 60;
 
 	MSecs = int(DiffMSecs % 1000);
 	Secs = int(DiffSecs % 60);
@@ -1252,7 +1252,7 @@ uint TTm::GetYearIntFromTm(const TTm& Tm) {
 }
 
 uint TTm::GetDateTimeIntFromTm(const TTm& Tm) {
-    return Tm.IsDef() ? 
+    return Tm.IsDef() ?
 		GetDateTimeInt(Tm.GetYear(), Tm.GetMonth(),
         Tm.GetDay(), Tm.GetHour(), Tm.GetMin(), Tm.GetSec()) : 0;
 }
@@ -1269,9 +1269,9 @@ TSecTm TTm::GetSecTmFromDateTimeInt(const uint& DateTimeInt) {
 
 /////////////////////////////////////////////////
 // Time-Profiler - poor-man's profiler
-int TTmProfiler::AddTimer(const TStr& TimerNm) { 
+int TTmProfiler::AddTimer(const TStr& TimerNm) {
 	MxNmLen = TInt::GetMx(MxNmLen, TimerNm.Len());
-	return TimerH.AddKey(TimerNm); 
+	return TimerH.AddKey(TimerNm);
 }
 
 void TTmProfiler::ResetAll() {

--- a/glib-core/tm.h
+++ b/glib-core/tm.h
@@ -313,7 +313,7 @@ public:
   static uint GetMSecsFromOsStart();
   static uint64 GetPerfTimerFq();
   static uint64 GetPerfTimerTicks();
-  static void GetDiff(const TTm& Tm1, const TTm& Tm2, int& Days, 
+  static void GetDiff(const TTm& Tm1, const TTm& Tm2, int& Days,
 	  int& Hours, int& Mins, int& Secs, int& MSecs);
   static uint64 GetDiffMSecs(const TTm& Tm1, const TTm& Tm2);
   static uint64 GetDiffSecs(const TTm& Tm1, const TTm& Tm2){
@@ -329,18 +329,18 @@ public:
   static TTm GetTmFromWebLogTimeStr(const TStr& TimeStr,
    const char TimeSepCh=':', const char MSecSepCh='.');
   static TTm GetTmFromWebLogDateTimeStr(const TStr& DateTimeStr,
-   const char DateSepCh='-', const char TimeSepCh=':', 
+   const char DateSepCh='-', const char TimeSepCh=':',
    const char MSecSepCh='.', const char DateTimeSepCh=' ');
   static TTm GetTmFromIdStr(const TStr& IdStr);
-  
+
   // get unix timestamp
-  static uint GetDateTimeInt(const int& Year = 0, const int& Month = 0, 
+  static uint GetDateTimeInt(const int& Year = 0, const int& Month = 0,
     const int& Day = 1, const int& Hour = 0, const int& Min = 0,
-	const int& Sec = 0);   
-  static uint GetDateIntFromTm(const TTm& Tm);   
+	const int& Sec = 0);
+  static uint GetDateIntFromTm(const TTm& Tm);
   static uint GetMonthIntFromTm(const TTm& Tm);
   static uint GetYearIntFromTm(const TTm& Tm);
-  static uint GetDateTimeIntFromTm(const TTm& Tm);   
+  static uint GetDateTimeIntFromTm(const TTm& Tm);
   static TTm GetTmFromDateTimeInt(const uint& DateTimeInt);
   static TSecTm GetSecTmFromDateTimeInt(const uint& DateTimeInt);
 };
@@ -371,7 +371,7 @@ public:
     if (GetSecs() < 60) { sprintf(TmStr, "%.2fs", GetSecs()); }
     else if (GetSecs() < 3600) { sprintf(TmStr, "%02dm%02ds", int(GetSecs())/60, int(GetSecs())%60); }
     else { sprintf(TmStr, "%02dh%02dm", int(GetSecs())/3600, (int(GetSecs())%3600)/60); }  return TmStr; }
-  static char* GetCurTm(){ static TStr TmStr; TmStr=TSecTm::GetCurTm().GetTmStr(); return TmStr.CStr(); }
+  static const char* GetCurTm(){ static TStr TmStr; TmStr=TSecTm::GetCurTm().GetTmStr(); return TmStr.CStr(); }
 };
 
 /////////////////////////////////////////////////
@@ -432,7 +432,7 @@ public:
 // Timer
 class TTmTimer {
 private:
-    int MxMSecs; 
+    int MxMSecs;
     TTmStopWatch StopWatch;
 
     UndefDefaultCopyAssign(TTmTimer);

--- a/glib-core/unicode.cpp
+++ b/glib-core/unicode.cpp
@@ -1275,7 +1275,7 @@ void TUniChDb::LoadTxt(const TStr& basePath)
 		ci.chCat = s[0]; ci.chSubCat = s[1];
 		// Canonical combining class.
 		s = fields[3]; IAssert(s.Len() > 0);
-		int i; bool ok = s.IsInt(true, TUCh::Mn, TUCh::Mx, i); IAssertR(ok, s);
+		int i = 0; bool ok = s.IsInt(true, TUCh::Mn, TUCh::Mx, i); IAssertR(ok, s);
 		ci.combClass = (uchar) i;
 		// Decomposition type and mapping.
 		LoadTxt_ProcessDecomposition(ci, fields[5]);

--- a/glib-core/unicode.cpp
+++ b/glib-core/unicode.cpp
@@ -757,7 +757,7 @@ void TUniChDb::TestComposition(const TStr& basePath)
 	{
 		nLines += 1;
 		if (fields.Len() == 1) {
-			IAssert(fields[0].IsPrefix("@Part"));
+			IAssert(fields[0].StartsWith("@Part"));
 			inPart1 = (fields[0] == "@Part1"); continue; }
 		IAssert(fields.Len() == 6);
 		IAssert(fields[5].Len() == 0);

--- a/glib-core/url.cpp
+++ b/glib-core/url.cpp
@@ -89,7 +89,7 @@ public:
     for (int ChN=0; ChN<Str.Len(); ChN++){GetCh(Str[ChN]);} return Str;}
   const char* GetStr(const char *Str){
 	int Len = (int) strlen(Str);
-    for (int ChN=0; ChN<Len; ChN++){GetCh(Str[ChN]);} 
+    for (int ChN=0; ChN<Len; ChN++){GetCh(Str[ChN]);}
 	return Str;
   }
 
@@ -164,16 +164,16 @@ void TUrl::GetAbs(const TStr& AbsUrlStr){
     else if (PortN==THttp::DfPortN){PortStr.Clr();}
     //**if (!PortStr.Empty()){Str+=':'; Str+=PortStr;}
     if (Lx.PeekCh()=='/'){
-      PathStr=Lx.GetCh('/'); PathStr+=Lx.GetHPath(PathSegV); Str+=PathStr;}
+      PathStr=TStr(Lx.GetCh('/')); PathStr+=Lx.GetHPath(PathSegV); Str+=PathStr;}
     if (PathStr.Empty()){PathStr="/"; Str+=PathStr;}
     if (Lx.PeekCh()=='?'){
-      SearchStr=Lx.GetCh('?'); SearchStr+=Lx.GetSearch(); Str+=SearchStr;}
+      SearchStr=TStr(Lx.GetCh('?')); SearchStr+=Lx.GetSearch(); Str+=SearchStr;}
   } else {
     Scheme=usOther; Str+=Lx.GetToCh();
   }
   while (Lx.PeekCh()==' '){Lx.GetCh();}
   if (Lx.PeekCh()=='#'){
-    FragIdStr=Lx.GetCh('#'); FragIdStr+=Lx.GetToCh();
+    FragIdStr=TStr(Lx.GetCh('#')); FragIdStr+=Lx.GetToCh();
   }
   EAssertR(Lx.Eof(), "");
   UrlStr=Str;
@@ -185,7 +185,7 @@ void TUrl::GetAbsFromBase(const TStr& RelUrlStr, const TStr& BaseUrlStr){
   EAssertR(IsAbs(BaseUrlStr), "");
   TStr AbsUrlStr=BaseUrlStr;
   TStr NrRelUrlStr=RelUrlStr;
-  if (NrRelUrlStr.GetLc().IsPrefix(UrlHttpPrefixStr)){
+  if (NrRelUrlStr.GetLc().StartsWith(UrlHttpPrefixStr)){
     NrRelUrlStr.DelSubStr(0, UrlHttpPrefixStr.Len()-1);}
   if (NrRelUrlStr.Len()>0){
     if (NrRelUrlStr[0]=='/'){
@@ -322,8 +322,8 @@ void TUrl::ToLcPath(){
 }
 
 bool TUrl::IsAbs(const TStr& UrlStr){
-  if (UrlStr.GetLc().IsPrefix(UrlHttpPrefixStr)){
-    return UrlStr.GetLc().IsPrefix(UrlHttpAbsPrefixStr);
+  if (UrlStr.GetLc().StartsWith(UrlHttpPrefixStr)){
+    return UrlStr.GetLc().StartsWith(UrlHttpAbsPrefixStr);
   } else {
     int ColonChN=UrlStr.SearchCh(':'); int SlashChN=UrlStr.SearchCh('/');
     return (ColonChN!=-1)&&((SlashChN==-1)||((SlashChN!=-1)&&(ColonChN<SlashChN)));
@@ -467,4 +467,3 @@ PUrlEnv TUrlEnv::MkClone(const PUrlEnv& UrlEnv){
    PUrlEnv(new TUrlEnv(*UrlEnv));
   return CloneUrlEnv;
 }
-

--- a/glib-core/url.h
+++ b/glib-core/url.h
@@ -76,9 +76,9 @@ public:
     HttpRqStr.ChangeStr(SrcStr, DstStr);}
 
   bool IsInHost(const TStr& _HostNm) const {
-    EAssert(IsOk()); return HostNm.GetUc().IsSuffix(_HostNm.GetUc());}
+    EAssert(IsOk()); return HostNm.GetUc().EndsWith(_HostNm.GetUc());}
   bool IsInPath(const TStr& _PathStr) const {
-    EAssert(IsOk()); return PathStr.GetUc().IsPrefix(_PathStr.GetUc());}
+    EAssert(IsOk()); return PathStr.GetUc().StartsWith(_PathStr.GetUc());}
   void ToLcPath();
 
   static bool IsAbs(const TStr& UrlStr);
@@ -169,4 +169,3 @@ public:
 
   static PUrlEnv MkClone(const PUrlEnv& UrlEnv);
 };
-

--- a/glib-core/ut.h
+++ b/glib-core/ut.h
@@ -6,7 +6,7 @@ template <class Type>
 class TTypeNm: public TStr{
 public:
   static TStr GetNrTypeNm(const TStr& TypeNm){
-    if (TypeNm.IsPrefix("class ")){
+    if (TypeNm.StartsWith("class ")){
       return TypeNm.GetSubStr(6, TypeNm.Len()-1);}
     else {return TypeNm;}}
 public:
@@ -89,12 +89,12 @@ public:
   void OnNotify(const TNotifyType& Type, const TStr& MsgStr)
   {
     Assert(CallbackF != NULL);
-    CallbackF(Type, MsgStr); 
+    CallbackF(Type, MsgStr);
   }
   void OnStatus(const TStr& MsgStr)
   {
     Assert(CallbackF != NULL);
-    CallbackF(ntStat, MsgStr); 
+    CallbackF(ntStat, MsgStr);
   }
 };
 
@@ -112,12 +112,12 @@ public:
   void OnNotify(const TNotifyType& Type, const TStr& MsgStr)
   {
     Assert(CallbackF != NULL);
-    CallbackF((int)Type, MsgStr.CStr()); 
+    CallbackF((int)Type, MsgStr.CStr());
   }
   void OnStatus(const TStr& MsgStr)
   {
     Assert(CallbackF != NULL);
-    CallbackF((int)ntStat, MsgStr.CStr()); 
+    CallbackF((int)ntStat, MsgStr.CStr());
   }
 };
 

--- a/glib-core/zipfl.cpp
+++ b/glib-core/zipfl.cpp
@@ -5,9 +5,9 @@
   TStr TZipIn::SevenZipPath = "C:\\7Zip";
 #elif defined(GLib_CYGWIN)
   TStr TZipIn::SevenZipPath = "/usr/bin";
-#elif defined(GLib_MACOSX) 
+#elif defined(GLib_MACOSX)
   TStr TZipIn::SevenZipPath = "/usr/local/bin";
-#else 
+#else
   TStr TZipIn::SevenZipPath = "/usr/bin";
 #endif
 
@@ -279,7 +279,7 @@ uint64 TZipIn::GetFLen(const TStr& ZipFNm) {
   TStr Str(Bf);  delete [] Bf;
   TStrV StrV; Str.SplitOnWs(StrV);
   int n = StrV.Len()-1;
-  while (n > 0 && ! StrV[n].IsPrefix("-----")) { n--; }
+  while (n > 0 && ! StrV[n].StartsWith("-----")) { n--; }
   if (n-7 <= 0) {
     WrNotify(TStr::Fmt("Corrupt file %s: MESSAGE:\n", ZipFNm.CStr()).CStr(), Str.CStr());
     SaveToErrLog(TStr::Fmt("Corrupt file %s. Message:\n:%s\n", ZipFNm.CStr(), Str.CStr()).CStr());

--- a/snap-adv/mag.cpp
+++ b/snap-adv/mag.cpp
@@ -202,7 +202,7 @@ void TMAGNodeSimple::AttrGen(TIntVV& AttrVV, const int& NNodes) {
 	IAssert(Dim > 0);
 	AttrVV.Gen(NNodes, Dim);
 	AttrVV.PutAll(0);
-	
+
 	for(int i = 0; i < NNodes; i++) {
 		for(int l = 0; l < Dim; l++) {
 			if((TMAGNodeSimple::Rnd).GetUniDev() > Mu) {
@@ -239,7 +239,7 @@ void TMAGNodeSimple::SaveTxt(TStrV& OutStrV) const {
 
 
 /////////////////////////////////////////////////
-// MAG node attributes with (different) Bernoulli 
+// MAG node attributes with (different) Bernoulli
 
 TMAGNodeBern& TMAGNodeBern::operator=(const TMAGNodeBern& Dist) {
 	MuV = Dist.MuV;
@@ -251,7 +251,7 @@ void TMAGNodeBern::AttrGen(TIntVV& AttrVV, const int& NNodes) {
 	IAssert(Dim > 0);
 	AttrVV.Gen(NNodes, Dim);
 	AttrVV.PutAll(0);
-	
+
 	for(int i = 0; i < NNodes; i++) {
 		for(int l = 0; l < Dim; l++) {
 			if((TMAGNodeBern::Rnd).GetUniDev() > MuV[l]) {
@@ -311,7 +311,7 @@ void TMAGNodeBeta::SetBeta(const int& Attr, const double& Alpha, const double& B
 	BetaV[Attr] = Beta;
 	Dirty = true;
 }
-	
+
 void TMAGNodeBeta::SetBetaV(const TFltV& _AlphaV, const TFltV& _BetaV) {
 	IAssert(_AlphaV.Len() == _BetaV.Len());
 	AlphaV = _AlphaV;
@@ -326,7 +326,7 @@ void TMAGNodeBeta::AttrGen(TIntVV& AttrVV, const int& NNodes) {
 	AttrVV.PutAll(0);
 
 //	printf("AlphaV = %d, BetaV = %d, MuV = %d\n", AlphaV.Len(), BetaV.Len(), MuV.Len());
-	
+
 	for(int i = 0; i < NNodes; i++) {
 		for(int l = 0; l < Dim; l++) {
 			double x = TMAGNodeBeta::Rnd.GetGammaDev((int)AlphaV[l]);
@@ -355,7 +355,7 @@ void TMAGNodeBeta::LoadTxt(const TStr& InFNm) {
 
 	while(fgets(buf, sizeof(buf), fp) != NULL) {
 		token = strtok(buf, "&");
-		
+
 		token = strtok(token, " \t");
 		TokenStr = TStr(token);
 		AlphaV.Add(TokenStr.GetFlt(Val));
@@ -402,7 +402,7 @@ void TMAGFitBern::SetPhiVV(const TIntVV& AttrVV, const int KnownIds) {
 
 	PhiVV.Gen(NNodes, NAttrs);
 	KnownVV.Gen(NNodes, NAttrs);
-	
+
 	for(int l = 0; l < NAttrs; l++) {
 		for(int i = 0; i < NNodes; i++) {
 			if(int(AttrVV(i, l)) == 0) {
@@ -427,7 +427,7 @@ void TMAGFitBern::SaveTxt(const TStr& FNm) {
 	TMAGAffMtxV MtxV;
 	Param.GetMtxV(MtxV);
 
-	FILE *fp = fopen(FNm.GetCStr(), "w");
+	FILE *fp = fopen(FNm.CStr(), "w");
 	for(int l = 0; l < NAttrs; l++) {
 		fprintf(fp, "%.4f\t", double(MuV[l]));
 		for(int row = 0; row < 2; row++) {
@@ -448,7 +448,7 @@ void TMAGFitBern::SaveTxt(const TStr& FNm) {
 	}
 	fclose(fp);
 }
-	
+
 void TMAGFitBern::Init(const TFltV& MuV, const TMAGAffMtxV& AffMtxV) {
 	TMAGNodeBern DistParam(MuV);
 	Param.SetNodeAttr(DistParam);
@@ -474,7 +474,7 @@ void TMAGFitBern::PerturbInit(const TFltV& MuV, const TMAGAffMtxV& AffMtxV, cons
 
 	const int NNodes = Param.GetNodes();
 	const int NAttrs = Param.GetAttrs();
-	
+
 	for(int l = 0; l < NAttrs; l++) {
 		double Mu = MuV[l] + PerturbRate * (Rnd.GetUniDev() - 0.5) * 2;
 //		double Mu = 0.5;
@@ -500,7 +500,7 @@ void TMAGFitBern::PerturbInit(const TFltV& MuV, const TMAGAffMtxV& AffMtxV, cons
 	}
 	Param.SetMtxV(PerturbMtxV);
 	Param.SetNodeAttr(DistParam);
-	
+
 	PhiVV.Gen(NNodes, NAttrs);
 	KnownVV.Gen(NNodes, NAttrs);
 	KnownVV.PutAll(false);
@@ -514,10 +514,10 @@ void TMAGFitBern::RandomInit(const TFltV& MuV, const TMAGAffMtxV& AffMtxV, const
 	TFltV InitMuV = MuV;	InitMuV.PutAll(0.5);
 	TMAGNodeBern DistParam(InitMuV);
 	Param.SetMtxV(AffMtxV);
-	
+
 	const int NNodes = Param.GetNodes();
 	const int NAttrs = Param.GetAttrs();
-	
+
 	PhiVV.Gen(NNodes, NAttrs);
 	KnownVV.Gen(NNodes, NAttrs);
 	KnownVV.PutAll(false);
@@ -528,7 +528,7 @@ void TMAGFitBern::RandomInit(const TFltV& MuV, const TMAGAffMtxV& AffMtxV, const
 //			PhiVV.At(i, l) = 0.5;
 		}
 	}
-	
+
 	TMAGAffMtxV RndMtxV = AffMtxV;
 	for(int l = 0; l < NAttrs; l++) {
 		for(int p = 0; p < 4; p++) {
@@ -538,10 +538,10 @@ void TMAGFitBern::RandomInit(const TFltV& MuV, const TMAGAffMtxV& AffMtxV, const
 		}
 		RndMtxV[l].At(0, 1) = RndMtxV[l].At(1, 0);
 	}
-	
+
 	printf("\n");
 	for(int l = 0; l < NAttrs; l++) {
-		printf("AffMtx = %s\n", RndMtxV[l].GetMtxStr().GetCStr());
+		printf("AffMtx = %s\n", RndMtxV[l].GetMtxStr().CStr());
 	}
 	Param.SetMtxV(RndMtxV);
 	Param.SetNodeAttr(DistParam);
@@ -681,11 +681,11 @@ const double LogSumExp(const double LogVal1, const double LogVal2) {
 const double LogSumExp(const TFltV& LogValV) {
 	const int Len = LogValV.Len();
 	double MaxExp = -DBL_MAX;
-	
+
 	for(int i = 0; i < Len; i++) {
 		if(MaxExp < LogValV[i]) {  MaxExp = LogValV[i];  }
 	}
-	
+
 	double Sum = 0.0;
 	for(int i = 0; i < Len; i++) {
 		Sum += exp(LogValV[i] - MaxExp);
@@ -746,7 +746,7 @@ const double TMAGFitBern::ObjPhiMI(const double& x, const int& NId, const int& A
 const double TMAGFitBern::GetEstNoEdgeLL(const int& NId, const int& AId) const {
 	// const int NNodes = Param.GetNodes();
 	// const int NAttrs = Param.GetAttrs();
-	
+
 	TMAGNodeBern DistParam = Param.GetNodeAttr();
 	double LL = 0.0;
 
@@ -754,7 +754,7 @@ const double TMAGFitBern::GetEstNoEdgeLL(const int& NId, const int& AId) const {
 }
 
 const double TMAGFitBern::UpdatePhi(const int& NId, const int& AId, double& Phi) {
-	TMAGAffMtx LLTheta, Theta = Param.GetMtx(AId); 
+	TMAGAffMtx LLTheta, Theta = Param.GetMtx(AId);
 	TMAGAffMtx SqTheta(Theta);
 	const int NNodes = Param.GetNodes();
 	// const int NAttrs = Param.GetAttrs();
@@ -776,7 +776,7 @@ const double TMAGFitBern::UpdatePhi(const int& NId, const int& AId, double& Phi)
 		//MaxExp[i] = -DBL_MAX;
 		NonEdgeLLV[i].Gen(4 * NNodes, 0);
 	}
-	
+
 	for(int j = 0; j < NNodes; j++) {
 		if(j == NId) {	continue;	}
 
@@ -809,7 +809,7 @@ const double TMAGFitBern::UpdatePhi(const int& NId, const int& AId, double& Phi)
 
 	NonEdgeQ[0] = LogSumExp(NonEdgeLLV[0]);
 	NonEdgeQ[1] = LogSumExp(NonEdgeLLV[1]);
-	
+
 	double Q[2];
 	Q[0] = log(Mu) + EdgeQ[0] - exp(NonEdgeQ[0]);
 	Q[1] = log(1.0 - Mu) + EdgeQ[1] - exp(NonEdgeQ[1]);
@@ -825,7 +825,7 @@ const double TMAGFitBern::UpdatePhi(const int& NId, const int& AId, double& Phi)
 
 
 const double TMAGFitBern::UpdatePhiMI(const double& Lambda, const int& NId, const int& AId, double& Phi) {
-	TMAGAffMtx LLTheta, Theta = Param.GetMtx(AId); 
+	TMAGAffMtx LLTheta, Theta = Param.GetMtx(AId);
 	TMAGAffMtx SqTheta(Theta);
 	const int NNodes = Param.GetNodes();
 	const int NAttrs = Param.GetAttrs();
@@ -848,7 +848,7 @@ const double TMAGFitBern::UpdatePhiMI(const double& Lambda, const int& NId, cons
 		//MaxExp[i] = -DBL_MAX;
 		NonEdgeLLV[i].Gen(4 * NNodes, 0);
 	}
-	
+
 	for(int j = 0; j < NNodes; j++) {
 		if(j == NId) {	continue;	}
 
@@ -886,10 +886,10 @@ const double TMAGFitBern::UpdatePhiMI(const double& Lambda, const int& NId, cons
 			}
 		}
 	}
-	
+
 	NonEdgeQ[0] = LogSumExp(NonEdgeLLV[0]);
 	NonEdgeQ[1] = LogSumExp(NonEdgeLLV[1]);
-	
+
 	double Q[2];
 	Q[0] = log(Mu) + EdgeQ[0] - exp(NonEdgeQ[0]);
 	Q[1] = log(1.0 - Mu) + EdgeQ[1] - exp(NonEdgeQ[1]);
@@ -930,7 +930,7 @@ const double TMAGFitBern::UpdatePhiMI(const double& Lambda, const int& NId, cons
 
 
 const double TMAGFitBern::UpdateApxPhiMI(const double& Lambda, const int& NId, const int& AId, double& Phi, TFltVV& ProdVV) {
-	TMAGAffMtx LLTheta, Theta = Param.GetMtx(AId); 
+	TMAGAffMtx LLTheta, Theta = Param.GetMtx(AId);
 	const int NNodes = Param.GetNodes();
 	const int NAttrs = Param.GetAttrs();
 	Theta.GetLLMtx(LLTheta);
@@ -968,7 +968,7 @@ const double TMAGFitBern::UpdateApxPhiMI(const double& Lambda, const int& NId, c
 	EdgeQ[0] = -(NNodes - 1) * exp(LogSumExp(NonEdgeLLV[0]));
 	EdgeQ[1] = -(NNodes - 1) * exp(LogSumExp(NonEdgeLLV[1]));
 
-	
+
 	for(int l = 0; l < NAttrs; l++) {
 		if(l == AId) {  continue;  }
 		int BgId = (AId > l) ? AId : l;
@@ -1094,7 +1094,7 @@ double TMAGFitBern::DoEStepOneIter(const TFltV& TrueMuV, TFltVV& NewPhiVV, const
 
 //			PhiVV.At(NId, AId) = Val;
 			NewVal[l] = TFltIntIntTr(Val, NId, AId);
-			
+
 //			MuV[AId] = MuV[AId] + Val;
 			if(fabs(Delta) > MaxDelta) {
 				MaxDelta = fabs(Delta);
@@ -1193,7 +1193,7 @@ double TMAGFitBern::DoEStepApxOneIter(const TFltV& TrueMuV, TFltVV& NewPhiVV, co
 
 //			PhiVV.At(NId, AId) = Val;
 			NewVal[l] = TFltIntIntTr(Val, NId, AId);
-			
+
 //			MuV[AId] = MuV[AId] + Val;
 			if(fabs(Delta) > MaxDelta) {
 				MaxDelta = fabs(Delta);
@@ -1227,7 +1227,7 @@ double TMAGFitBern::DoEStepApxOneIter(const TFltV& TrueMuV, TFltVV& NewPhiVV, co
 			AvgPhiV[AId] -= PhiVV(NId, AId);
 
 			PhiVV.At(NId, AId) = NewVal[l].Val1;
-			
+
 			ProdVV(NId, 0) += GetAvgThetaLL(NId, NId, AId, true, false);
 			ProdVV(NId, 1) += GetAvgThetaLL(NId, NId, AId, false, true);
 			ProdVV(NId, 2) += GetAvgSqThetaLL(NId, NId, AId, true, false);
@@ -1324,7 +1324,7 @@ const void TMAGFitBern::GradAffMtx(const int& AId, const TFltVV& ProdVV, const T
 	const int NNodes = Param.GetNodes();
 	// const int NAttrs = Param.GetAttrs();
 	GradV.PutAll(0.0);
-	
+
 	for(int i = 0; i < NNodes; i++) {
 		for(int j = 0; j < NNodes; j++) {
 			double Prod = ProdVV(i, j) - GetThetaLL(i, j, AId);
@@ -1372,7 +1372,7 @@ const void TMAGFitBern::GradApxAffMtx(const int& AId, const TFltVV& ProdVV, cons
 		double LogSum = LogSumExp(LogSumV);
 		GradV[p] -= (NNodes - 1) * 0.5 * exp(LogSum);
 	}
-	
+
 	for(TNGraph::TEdgeI EI = Graph->BegEI(); EI < Graph->EndEI(); EI++) {
 		const int NId1 = EI.GetSrcNId();
 		const int NId2 = EI.GetDstNId();
@@ -1447,8 +1447,8 @@ const double TMAGFitBern::UpdateAffMtx(const int& AId, const double& LrnRate, co
 	}
 
 	printf("      [Attr = %d]\n", AId);
-    printf("        %s  + [%f, %f; %f %f]  ----->  %s\n", (AffMtx.GetMtxStr()).GetCStr(), double(GradV[0]), double(GradV[1]), double(GradV[2]), double(GradV[3]), (NewMtx.GetMtxStr()).GetCStr());
-	
+    printf("        %s  + [%f, %f; %f %f]  ----->  %s\n", (AffMtx.GetMtxStr()).CStr(), double(GradV[0]), double(GradV[1]), double(GradV[2]), double(GradV[3]), (NewMtx.GetMtxStr()).CStr());
+
 //	Param.SetMtx(AId, NewMtx);
 	return Delta;
 }
@@ -1459,7 +1459,7 @@ void TMAGFitBern::NormalizeAffMtxV(TMAGAffMtxV& MtxV, const bool UseMu) {
 	const int NAttrs = MtxV.Len();
 	TFltV MuV = GetMuV();
 	double Product = 1.0, ExpEdge = NNodes * (NNodes - 1);
-	
+
 	TFltV SumV(NAttrs), EdgeSumV(NAttrs);
 	SumV.PutAll(0.0);	EdgeSumV.PutAll(0.0);
 	for(int l = 0; l < NAttrs; l++) {
@@ -1480,7 +1480,7 @@ void TMAGFitBern::NormalizeAffMtxV(TMAGAffMtxV& MtxV, const bool UseMu) {
 //	NormConst = ExpEdge;
 	Product = 1.0;
 //	Product = pow(Product * ExpEdge, 1.0 / double(NAttrs));
-	
+
 	for(int l = 0; l < NAttrs; l++) {
 		for(int p = 0; p < 4; p++) {
 			MtxV[l].At(p) = MtxV[l].At(p) * Product / SumV[l];
@@ -1498,7 +1498,7 @@ void TMAGFitBern::UnNormalizeAffMtxV(TMAGAffMtxV& MtxV, const bool UseMu) {
 	TFltIntPrV MaxEntV(NAttrs);
 	TFltV MuV = GetMuV();
 	NormalizeAffMtxV(MtxV, UseMu);
-	
+
 	double ExpEdge = NNodes * (NNodes - 1);
 	for(int l = 0; l < NAttrs; l++) {
 		double Mu = MuV[l];
@@ -1510,7 +1510,7 @@ void TMAGFitBern::UnNormalizeAffMtxV(TMAGAffMtxV& MtxV, const bool UseMu) {
 	}
 	NormConst = double(Graph->GetEdges()) / ExpEdge;
 //	NormConst *= ExpEdge;
-	
+
 	for(int l = 0; l < NAttrs; l++) {
 		MaxEntV[l] = TFltIntPr(-1, l);
 		for(int p = 0; p < 4; p++) {
@@ -1557,7 +1557,7 @@ const void TMAGFitBern::PrepareUpdateApxAffMtx(TFltVV& ProdVV, TFltVV& SqVV) {
 		SqVV(i, 1) = GetAvgProdSqWeight(i, i, false, true);
 	}
 }
-	
+
 const double TMAGFitBern::UpdateAffMtxV(const int& GradIter, const double& LrnRate, const double& MaxGrad, const double& Lambda, const int& NReal) {
 	const int NNodes = Param.GetNodes();
 	const int NAttrs = Param.GetAttrs();
@@ -1565,7 +1565,7 @@ const double TMAGFitBern::UpdateAffMtxV(const int& GradIter, const double& LrnRa
 	const TFltV MuV = DistParam.GetMuV();
 	double Delta = 0.0;
 	double DecLrnRate = LrnRate, DecMaxGrad = MaxGrad;
-	
+
 	TFltVV ProdVV(NNodes, NNodes), SqVV(NNodes, NNodes);
 	TMAGAffMtxV NewMtxV, OldMtxV;
 	Param.GetMtxV(OldMtxV);
@@ -1592,7 +1592,7 @@ const double TMAGFitBern::UpdateAffMtxV(const int& GradIter, const double& LrnRa
 		Param.SetMtxV(NewMtxV);
 	}
 	NormalizeAffMtxV(NewMtxV, true);
-	
+
 	printf( "\nFinal\n");
 	for(int l = 0; l < NAttrs; l++) {
 		printf("    [");
@@ -1614,7 +1614,7 @@ void TMAGFitBern::DoMStep(const int& GradIter, const double& LrnRate, const doub
 	double MuDelta = 0.0, AffMtxDelta = 0.0;
 
 	TExeTm ExeTm;
-	
+
 	printf("\n");
 	AvgPhiV.Gen(NAttrs);	AvgPhiV.PutAll(0.0);
 	for(int l = 0; l < NAttrs; l++) {
@@ -1649,7 +1649,7 @@ void TMAGFitBern::DoEMAlg(const int& NStep, const int& NEstep, const int& NMstep
 	TMAGNodeBern NodeAttr = Param.GetNodeAttr();
 	Param.GetMtxV(InitMtxV);
 	TFltV InitMuV = NodeAttr.GetMuV();
-	
+
 	for(int i = 0; i < NNodes; i++) {
 		for(int l = 0; l < NAttrs; l++) {
 			if(! KnownVV(i, l)) {
@@ -1657,7 +1657,7 @@ void TMAGFitBern::DoEMAlg(const int& NStep, const int& NEstep, const int& NMstep
 			}
 		}
 	}
-	
+
 	if(Debug) {
 		double LL = ComputeApxLL();
 		MuHisV.Add(InitMuV);
@@ -1672,7 +1672,7 @@ void TMAGFitBern::DoEMAlg(const int& NStep, const int& NEstep, const int& NMstep
 		printf("--------------------------------------------\n");
 		printf("EM Iteration : %d\n", (n+1));
 		printf("--------------------------------------------\n");
-		
+
 		NodeAttr = Param.GetNodeAttr();
 		for(int i = 0; i < NNodes; i++) {
 			for(int l = 0; l < NAttrs; l++) {
@@ -1735,7 +1735,7 @@ void TMAGFitBern::PlotProperties(const TStr& FNm) {
 	MAGGen.SetNodeAttr(MAGNode);
 	TMAGAffMtxV MtxV;	Param.GetMtxV(MtxV);
 	MAGGen.SetMtxV(MtxV);
-	
+
 	PNGraph TrG = new TNGraph;
 	*TrG = *Graph;
 
@@ -1750,12 +1750,12 @@ void TMAGFitBern::PlotProperties(const TStr& FNm) {
 //	PNGraph MAG = MAGGen.GenAttrMAG(AttrVV, true, 10000);
 	printf("%s edges created for MAG...\n",
         TUInt64::GetStr(MAG->GetEdges()).CStr());
-	
+
 	TSnap::DelZeroDegNodes(TrG);
 	TSnap::DelZeroDegNodes(MAG);
 
 	TGStatVec GS(tmuNodes, TFSet() | gsdInDeg | gsdOutDeg | gsdWcc | gsdHops | gsdClustCf | gsdSngVec | gsdSngVal | gsdTriadPart);
-	
+
     TGnuPlot InDegP(FNm + "-InDeg"), OutDegP(FNm + "-OutDeg"), SvalP(FNm + "-Sval"), SvecP(FNm + "-Svec"), WccP(FNm + "-Wcc"), HopP(FNm + "-Hop"), TriadP(FNm + "-Triad"), CcfP(FNm + "-Ccf");;
 
     InDegP.SetXYLabel("Degree", "# of nodes");
@@ -1781,7 +1781,7 @@ void TMAGFitBern::PlotProperties(const TStr& FNm) {
 	CcfP.ShowGrid(false);
 	HopP.ShowGrid(false);
 	TriadP.ShowGrid(false);
-	
+
 	const TStr Style[2] = {"lt 1 lw 3 lc rgb 'black'", "lt 2 lw 3 lc rgb 'red'"};
 	const TStr Name[2] = {"Real", "MAG"};
 	GS.Add(Graph, TSecTm(1), "Real Graph");
@@ -1841,7 +1841,7 @@ void TMAGFitBern::SortAttrOrdering(const TFltV& TrueMuV, TIntV& IndexV) const {
 		TrueIdxV[l] = l;
 		EstIdxV[l] = l;
 	}
-	
+
 	CountAttr(EstMuV);
 	SortedTrueMuV = TrueMuV;
 	SortedEstMuV = EstMuV;
@@ -1988,7 +1988,7 @@ const double TMAGFitBern::ComputeJointLL(int NSample) const {
 	for(int s = 0; s < NSample; s++) {
 		for(int i = 0; i < NNodes; i++) {
 			for(int l = 0; l < NAttrs; l++) {
-			
+
 				if(Rnd.GetUniDev() <= PhiVV(i, l)) {
 					AttrVV.At(i, l) = 0;
 				} else {
@@ -2117,7 +2117,7 @@ const double TMAGFitBern::ComputeMI(const TIntVV& AttrV, const int AId1, const i
       MI += Pxy(x, y) / double(NNodes) * (log(Pxy(x, y).Val) - log(Px[x].Val) - log(Py[y].Val) + log((double)NNodes));
 		}
 	}
-	
+
 	return MI;
 }
 
@@ -2131,7 +2131,7 @@ const double TMAGFitBern::ComputeMI(const TFltVV& AttrV, const int AId1, const i
 	Pxy.PutAll(0.0);
 	Px.PutAll(0.0);
 	Py.PutAll(0.0);
-	
+
 	for(int i = 0; i < NNodes; i++) {
 		double X = AttrV(i, AId1);
 		double Y = AttrV(i, AId2);
@@ -2145,13 +2145,13 @@ const double TMAGFitBern::ComputeMI(const TFltVV& AttrV, const int AId1, const i
 	}
 	Px[1] = NNodes - Px[0];
 	Py[1] = NNodes - Py[0];
-	
+
 	for(int x = 0; x < 2; x++) {
 		for(int y = 0; y < 2; y++) {
 			MI += Pxy(x, y) / double(NNodes) * (log(Pxy(x, y)) - log(Px[x]) - log(Py[y]) + log(double(NNodes)));
 		}
 	}
-	
+
 	return MI;
 }
 

--- a/snap-core/Snap.h
+++ b/snap-core/Snap.h
@@ -25,8 +25,8 @@
 
 // table data structures and algorithms
 #include "table.h"           // table
-#include "conv.h" 	         // conversion functions - table to graph
-#include "numpy.h" 	         // numpy conversion
+#include "conv.h" 	     // conversion functions - table to graph
+#include "numpy.h" 	     // numpy conversion
 
 // algorithms
 #include "subgraph.h"        // subgraph manipulations

--- a/snap-core/anf.h
+++ b/snap-core/anf.h
@@ -74,7 +74,7 @@ void TGraphAnf<PGraph>::InitAnfBits(TAnfBitV& BitV) {
   IAssertR(VSize <= TInt64::Mx,
     TStr::Fmt("Your graph is too large for Approximate Neighborhood Function, %s is larger than %d",
     TUInt64::GetStr(VSize).CStr(),TInt64::Mx));
-  printf("size %s\n", TInt64::GetStr(static_cast<int64>(VSize)).GetCStr());
+  printf("size %s\n", TInt64::GetStr(static_cast<int64>(VSize)).CStr());
   BitV.Gen((const int64)VSize);  IAssert(BitV.BegI() != NULL);
   BitV.PutAll(0);
   int64 SetBit = 0;

--- a/snap-core/casc.cpp
+++ b/snap-core/casc.cpp
@@ -50,7 +50,7 @@ PNGraph CascGraphSource(PTable P,const TStr C1,const TStr C2,const TStr C3,const
         if (!Graph->IsEdge(OIdx,InIdx)) {
           Graph->AddEdge(OIdx,InIdx);
         }
-      }      
+      }
     }
   }
   return Graph;
@@ -117,7 +117,7 @@ PNGraph CascGraphTime(PTable P,const TStr C1,const TStr C2,const TStr C3,const T
         if (!Graph->IsEdge(OIdx,InIdx)) {
           Graph->AddEdge(OIdx,InIdx);
         }
-      }      
+      }
     }
   }
   return Graph;
@@ -192,7 +192,7 @@ void CascFind(PNGraph Graph,PTable P,const TStr C1,const TStr C2,const TStr C3,c
                   TInt64::GetStr(PDest).CStr(),
                   TInt64::GetStr(PStart).CStr(),
                   TInt64::GetStr(PDur).CStr());
-      }   
+      }
     }
     if (ToAddV.Len() > 1) {
       TopCascVV.Add(ToAddV);
@@ -204,10 +204,10 @@ void CascFind(PNGraph Graph,PTable P,const TStr C1,const TStr C2,const TStr C3,c
 #ifdef USE_OPENMP
 void CascFindMP(PNGraph Graph,PTable P,const TStr C1,const TStr C2,const TStr C3,const TStr C4,TVec<TInt64V, int64> &TopCascVV) {
   // Attribute to Int mapping
-  TInt64 SIdx = P->GetColIdx(C1);
-  TInt64 DIdx = P->GetColIdx(C2);
-  TInt64 StIdx = P->GetColIdx(C3);
-  TInt64 DuIdx = P->GetColIdx(C4);
+  // TInt64 SIdx = P->GetColIdx(C1);
+  // TInt64 DIdx = P->GetColIdx(C2);
+  // TInt64 StIdx = P->GetColIdx(C3);
+  // TInt64 DuIdx = P->GetColIdx(C4);
   TInt64V MapV, PhyV;
   TStr64V SortBy;
   SortBy.Add(C3);
@@ -253,7 +253,7 @@ void CascFindMP(PNGraph Graph,PTable P,const TStr C1,const TStr C2,const TStr C3
       for (TInt64V::TIter VI = CurCasc.BegI(); VI < CurCasc.EndI(); VI++) {
         ToAddV.Add(MapV.GetVal(VI->Val));
       }
-      if (ToAddV.Len() > 1) { ThTopCascVV.Add(ToAddV);}  
+      if (ToAddV.Len() > 1) { ThTopCascVV.Add(ToAddV);}
     }
     #pragma omp critical
     {

--- a/snap-core/ff.cpp
+++ b/snap-core/ff.cpp
@@ -273,7 +273,7 @@ TStr TFfGGen::GetParamStr() const {
 }
 
 TFfGGen::TStopReason TFfGGen::AddNodes(const int64& GraphNodes, const bool& FloodStop) {
-  printf("\n***ForestFire:  %s  Nodes:%s  StartNodes:%s  Take2AmbProb:%g\n", BurnExpFire?"ExpFire":"GeoFire", TInt64::GetStr(GraphNodes).GetCStr(), TInt64::GetStr(StartNodes()).GetCStr(), Take2AmbProb());
+  printf("\n***ForestFire:  %s  Nodes:%s  StartNodes:%s  Take2AmbProb:%g\n", BurnExpFire?"ExpFire":"GeoFire", TInt64::GetStr(GraphNodes).CStr(), TInt64::GetStr(StartNodes()).CStr(), Take2AmbProb());
   printf("                FwdBurnP:%g  BckBurnP:%g  ProbDecay:%g  Orphan:%g\n", FwdBurnProb(), BckBurnProb(), ProbDecay(), OrphanProb());
   TExeTm ExeTm;
   int64 Burned1=0, Burned2=0, Burned3=0; // last 3 fire sizes
@@ -316,11 +316,11 @@ TFfGGen::TStopReason TFfGGen::AddNodes(const int64& GraphNodes, const bool& Floo
       Burned1=Burned2;  Burned2=Burned3;  Burned3=0;
     }
     if (NNodes % Kilo(1) == 0) {
-      printf("(%s, %s)  burned: [%s,%s,%s]  [%s]\n", TInt64::GetStr(NNodes).GetCStr(), TInt64::GetStr(NEdges).GetCStr(), TInt64::GetStr(Burned1).GetCStr(), TInt64::GetStr(Burned2).GetCStr(), TInt64::GetStr(Burned3).GetCStr(), ExeTm.GetStr()); }
+      printf("(%s, %s)  burned: [%s,%s,%s]  [%s]\n", TInt64::GetStr(NNodes).CStr(), TInt64::GetStr(NEdges).CStr(), TInt64::GetStr(Burned1).CStr(), TInt64::GetStr(Burned2).CStr(), TInt64::GetStr(Burned3).CStr(), ExeTm.GetStr()); }
     if (FloodStop && NEdges>GraphNodes && (NEdges/double(NNodes)>1000.0)) { // average node degree is more than 500
-      printf(". FLOOD. G(%s, %s)\n", TInt64::GetStr(NNodes).GetCStr(), TInt64::GetStr(NEdges).CStr());  return srFlood; }
+      printf(". FLOOD. G(%s, %s)\n", TInt64::GetStr(NNodes).CStr(), TInt64::GetStr(NEdges).CStr());  return srFlood; }
     if (NNodes % 1000 == 0 && TimeLimitSec > 0 && ExeTm.GetSecs() > TimeLimitSec) {
-      printf(". TIME LIMIT. G(%s, %s)\n", TInt64::GetStr(Graph->GetNodes()).GetCStr(), TInt64::GetStr(Graph->GetEdges()).GetCStr());
+      printf(". TIME LIMIT. G(%s, %s)\n", TInt64::GetStr(Graph->GetNodes()).CStr(), TInt64::GetStr(Graph->GetEdges()).CStr());
       return srTimeLimit; }
   }
   IAssert(Graph->GetEdges() == NEdges);
@@ -743,11 +743,11 @@ void TFfPhaseTrans::Merge(const TFfPhaseTrans& FfPhaseTrans) {
 /////////////////////////////////////////////////
 // Undirected Forest Fire (does not densify!)
 
-// Node selects N~geometric(1.0-BurnProb)-1 links and burns them. 
+// Node selects N~geometric(1.0-BurnProb)-1 links and burns them.
 // geometirc(p) has mean 1/(p), so for given BurnProb, we burn 1/(1-BurnProb) links in average
 int64 TUndirFFire::BurnGeoFire(const int64& StartNId) {
   BurnedSet.Clr(false);
-  BurningNIdV.Clr(false);  
+  BurningNIdV.Clr(false);
   NewBurnedNIdV.Clr(false);
   AliveNIdV.Clr(false);
   const TUNGraph& G = *Graph;
@@ -786,7 +786,7 @@ int64 TUndirFFire::BurnGeoFire(const int64& StartNId) {
 
 TFfGGen::TStopReason TUndirFFire::AddNodes(const int64& GraphNodes, const bool& FloodStop) {
   printf("\n***Undirected GEO ForestFire: graph(%s,%s) add %s nodes, burn prob %.3f\n",
-    TInt64::GetStr(Graph->GetNodes()).GetCStr(), TInt64::GetStr(Graph->GetEdges()).GetCStr(), TInt64::GetStr(GraphNodes).GetCStr(), BurnProb);
+    TInt64::GetStr(Graph->GetNodes()).CStr(), TInt64::GetStr(Graph->GetEdges()).CStr(), TInt64::GetStr(GraphNodes).CStr(), BurnProb);
   TExeTm ExeTm;
   int64 Burned1=0, Burned2=0, Burned3=0; // last 3 fire sizes
   TIntPr64V NodesEdgesV;
@@ -806,11 +806,11 @@ TFfGGen::TStopReason TUndirFFire::AddNodes(const int64& GraphNodes, const bool& 
     NEdges += NBurned;
     Burned1=Burned2;  Burned2=Burned3;  Burned3=NBurned;
     if (NNodes % Kilo(1) == 0) {
-      printf("(%s, %s)    burned: [%s,%s,%s]  [%s]\n", TInt64::GetStr(NNodes).GetCStr(), TInt64::GetStr(NEdges).GetCStr(), TInt64::GetStr(Burned1).GetCStr(), TInt64::GetStr(Burned2).GetCStr(), TInt64::GetStr(Burned3).GetCStr(), ExeTm.GetStr());
+      printf("(%s, %s)    burned: [%s,%s,%s]  [%s]\n", TInt64::GetStr(NNodes).CStr(), TInt64::GetStr(NEdges).CStr(), TInt64::GetStr(Burned1).CStr(), TInt64::GetStr(Burned2).CStr(), TInt64::GetStr(Burned3).CStr(), ExeTm.GetStr());
       NodesEdgesV.Add(TInt64Pr(NNodes, NEdges));
     }
     if (FloodStop && NEdges>1000 && NEdges/double(NNodes)>100.0) { // average node degree is more than 50
-      printf("!!! FLOOD. G(%s, %s)\n", TInt64::GetStr(NNodes).GetCStr(), TInt64::GetStr(NEdges).GetCStr());  return TFfGGen::srFlood; }
+      printf("!!! FLOOD. G(%s, %s)\n", TInt64::GetStr(NNodes).CStr(), TInt64::GetStr(NEdges).CStr());  return TFfGGen::srFlood; }
   }
   printf("\n");
   IAssert(Graph->GetEdges() == NEdges);

--- a/snap-core/gbase.h
+++ b/snap-core/gbase.h
@@ -120,8 +120,8 @@ void PrintInfo(const PGraph& Graph, const TStr& Desc, const TStr& OutFNm, const 
   }
   // print info
   fprintf(F, "\n");
-  fprintf(F, "  Nodes:                    %s\n", TInt64::GetStr(Graph->GetNodes()).GetCStr());
-  fprintf(F, "  Edges:                    %s\n", TInt64::GetStr(Graph->GetEdges()).GetCStr());
+  fprintf(F, "  Nodes:                    %s\n", TInt64::GetStr(Graph->GetNodes()).CStr());
+  fprintf(F, "  Edges:                    %s\n", TInt64::GetStr(Graph->GetEdges()).CStr());
   fprintf(F, "  Zero Deg Nodes:           %s\n", TInt64::GetStr(ZeroNodes).CStr());
   fprintf(F, "  Zero InDeg Nodes:         %s\n", TInt64::GetStr(ZeroInNodes).CStr());
   fprintf(F, "  Zero OutDeg Nodes:        %s\n", TInt64::GetStr(ZeroOutNodes).CStr());
@@ -335,4 +335,3 @@ void THeap<TVal, TCmp>::MakeHeap(const int64& First, const int64& Len) {
     Parent--;
   }
 }
-

--- a/snap-core/gio.cpp
+++ b/snap-core/gio.cpp
@@ -184,7 +184,7 @@ void WriteNodeSchemaToFile(FILE *F, TStr64V &IntAttrNNames, TStr64V &FltAttrNNam
 
 // Writes nodes out to the file. Each line consists of the node id followed by the
 // int attributes in the order specified by the TStrV IntAttrNNames, the float attributes
-// in the order specified by FltAttrNNames, and the string attributes specified by StrAttrNNames. 
+// in the order specified by FltAttrNNames, and the string attributes specified by StrAttrNNames.
 void WriteNodesToFile(FILE *F, const PNEANet& Graph, TStr64V &IntAttrNNames, TStr64V &FltAttrNNames, TStr64V &StrAttrNNames) {
   for (TNEANet::TNodeI NI = Graph->BegNI(); NI < Graph->EndNI(); NI++) {
     fprintf(F, "%s", TInt64::GetStr(NI.GetId()).CStr());
@@ -209,7 +209,7 @@ void WriteNodesToFile(FILE *F, const PNEANet& Graph, TStr64V &IntAttrNNames, TSt
         fprintf(F, "\t%s", NULL_VAL.CStr());
         continue;
       }
-      char * AttrStrVal = Graph->GetStrAttrDatN(NI.GetId(), StrAttrNNames[i]).CStr();
+      const char * AttrStrVal = Graph->GetStrAttrDatN(NI.GetId(), StrAttrNNames[i]).CStr();
       fprintf(F, "\t%s", AttrStrVal);
     }
     fprintf(F, "\n");
@@ -234,7 +234,7 @@ void WriteEdgeSchemaToFile(FILE *F, TStr64V &IntAttrENames, TStr64V &FltAttrENam
 
 // Writes edges out to the file. Each line consists of the SrcNId and DstNId followed by the
 // int attributes in the order specified by the TStrV IntAttrENames, the float attributes
-// in the order specified by FltAttrENames, and the string attributes specified by StrAttrENames. 
+// in the order specified by FltAttrENames, and the string attributes specified by StrAttrENames.
 void WriteEdgesToFile(FILE *F, const PNEANet& Graph, TStr64V &IntAttrENames, TStr64V &FltAttrENames, TStr64V &StrAttrENames) {
   for (TNEANet::TEdgeI EI = Graph->BegEI(); EI < Graph->EndEI(); EI++) {
     fprintf(F, "%s\t%s", TInt64::GetStr(EI.GetSrcNId()).CStr(), TInt64::GetStr(EI.GetDstNId()).CStr());
@@ -259,7 +259,7 @@ void WriteEdgesToFile(FILE *F, const PNEANet& Graph, TStr64V &IntAttrENames, TSt
         fprintf(F, "\t%s", NULL_VAL.CStr());
         continue;
       }
-      char * AttrStrVal = Graph->GetStrAttrDatE(EI.GetId(), StrAttrENames[i]).CStr();
+      const char * AttrStrVal = Graph->GetStrAttrDatE(EI.GetId(), StrAttrENames[i]).CStr();
       fprintf(F, "\t%s", AttrStrVal);
     }
     fprintf(F, "\n");
@@ -279,7 +279,7 @@ void SaveEdgeListNet(const PNEANet& Graph, const TStr& OutFNm, const TStr& Desc)
   WriteNodeSchemaToFile(F, IntAttrNNames, FltAttrNNames, StrAttrNNames);
   WriteNodesToFile(F, Graph, IntAttrNNames, FltAttrNNames, StrAttrNNames);
   fprintf(F, "%s\n", END_SENTINEL.CStr());
-  
+
   TStr64V IntAttrENames;
   TStr64V FltAttrENames;
   TStr64V StrAttrENames;

--- a/snap-core/graph.h
+++ b/snap-core/graph.h
@@ -73,9 +73,14 @@ public:
     /// Decrement iterator.
     TNodeI& operator-- (int) { NodeHI--; return *this; }
 
-
     bool operator < (const TNodeI& NodeI) const { return NodeHI < NodeI.NodeHI; }
     bool operator == (const TNodeI& NodeI) const { return NodeHI == NodeI.NodeHI; }
+
+    /// Following functions are required for C++11 range loops
+    TNodeI& operator++ () { return operator++(0); }
+    bool operator != (const TNodeI& NodeI) const { return !(NodeI == *this); }
+    const TNodeI& operator*() const { return *this; }
+    TNodeI& operator*() { return *this; }
 
     /// Returns ID of the current node.
     int64 GetId() const { return NodeHI.GetDat().GetId(); }
@@ -115,6 +120,11 @@ public:
     TEdgeI& operator++ (int) { do { CurEdge++; if (CurEdge >= CurNode.GetOutDeg()) { CurEdge=0; CurNode++; while (CurNode < EndNode && CurNode.GetOutDeg()==0) { CurNode++; } } } while (CurNode < EndNode && GetSrcNId()>GetDstNId()); return *this; }
     bool operator < (const TEdgeI& EdgeI) const { return CurNode<EdgeI.CurNode || (CurNode==EdgeI.CurNode && CurEdge<EdgeI.CurEdge); }
     bool operator == (const TEdgeI& EdgeI) const { return CurNode == EdgeI.CurNode && CurEdge == EdgeI.CurEdge; }
+    /// Following functions are required for C++11 range loops
+    TEdgeI& operator++ () { return operator++(0); }
+    bool operator != (const TEdgeI& EdgeI) const { return !(EdgeI == *this); }
+    const TEdgeI& operator*() const { return *this; }
+    TEdgeI& operator*() { return *this; }
     /// Returns edge ID. Always returns -1 since only edges in multigraphs have explicit IDs.
     int64 GetId() const { return -1; }
     /// Returns the source of the edge. Since the graph is undirected, this is the node with a smaller ID of the edge endpoints.
@@ -167,7 +177,7 @@ public:
   bool HasFlag(const TGraphFlag& Flag) const;
   TUNGraph& operator = (const TUNGraph& Graph) {
     if (this!=&Graph) { MxNId=Graph.MxNId; NEdges=Graph.NEdges; NodeH=Graph.NodeH; } return *this; }
-  
+
   /// Returns the number of nodes in the graph.
   int64 GetNodes() const { return NodeH.Len(); }
   /// Adds a node of ID NId to the graph. ##TUNGraph::AddNode
@@ -192,6 +202,8 @@ public:
   TNodeI EndNI() const { return TNodeI(NodeH.EndI()); }
   /// Returns an iterator referring to the node of ID NId in the graph.
   TNodeI GetNI(const int64& NId) const { return TNodeI(NodeH.GetI(NId)); }
+  /// Returns wraper for C++ range-based loops over nodes
+  TIterNode<TUNGraph> GetNI() const { return TIterNode<TUNGraph>(this); }
   /// Returns an ID that is larger than any node ID in the graph.
   int64 GetMxNId() const { return MxNId; }
 
@@ -217,6 +229,8 @@ public:
   TEdgeI GetEI(const int64& EId) const;
   /// Returns an iterator referring to edge (SrcNId, DstNId) in the graph. ##TUNGraph::GetEI
   TEdgeI GetEI(const int64& SrcNId, const int64& DstNId) const;
+  /// Returns wraper for C++ range-based loops over edges
+  TIterEdge<TUNGraph> GetEI() const { return TIterEdge<TUNGraph>(this); }
 
   /// Returns an ID of a random node in the graph.
   int64 GetRndNId(TRnd& Rnd=TInt::Rnd) { return NodeH.GetKey(NodeH.GetRndKeyId(Rnd, 0.8)); }
@@ -303,6 +317,13 @@ public:
 
     bool operator < (const TNodeI& NodeI) const { return NodeHI < NodeI.NodeHI; }
     bool operator == (const TNodeI& NodeI) const { return NodeHI == NodeI.NodeHI; }
+
+    /// Following functions are required for C++11 range loops
+    TNodeI& operator++ () { return operator++(0); }
+    bool operator != (const TNodeI& NodeI) const { return !(NodeI == *this); }
+    const TNodeI& operator*() const { return *this; }
+    TNodeI& operator*() { return *this; }
+
     /// Returns ID of the current node.
     int64 GetId() const { return NodeHI.GetDat().GetId(); }
     /// Returns degree of the current node, the sum of in-degree and out-degree.
@@ -342,6 +363,11 @@ public:
       while (CurNode < EndNode && CurNode.GetOutDeg()==0) { CurNode++; } }  return *this; }
     bool operator < (const TEdgeI& EdgeI) const { return CurNode<EdgeI.CurNode || (CurNode==EdgeI.CurNode && CurEdge<EdgeI.CurEdge); }
     bool operator == (const TEdgeI& EdgeI) const { return CurNode == EdgeI.CurNode && CurEdge == EdgeI.CurEdge; }
+    /// Following functions are required for C++11 range loops
+    TEdgeI& operator++ () { return operator++(0); }
+    bool operator != (const TEdgeI& EdgeI) const { return !(EdgeI == *this); }
+    const TEdgeI& operator*() const { return *this; }
+    TEdgeI& operator*() { return *this; }
     /// Returns edge ID. Always returns -1 since only edges in multigraphs have explicit IDs.
     int64 GetId() const { return -1; }
     /// Returns the source node of the edge.
@@ -394,7 +420,7 @@ public:
   bool HasFlag(const TGraphFlag& Flag) const;
   TNGraph& operator = (const TNGraph& Graph) {
     if (this!=&Graph) { MxNId=Graph.MxNId; NodeH=Graph.NodeH; }  return *this; }
-  
+
   /// Returns the number of nodes in the graph.
   int64 GetNodes() const { return NodeH.Len(); }
   /// Adds a node of ID NId to the graph. ##TNGraph::AddNode
@@ -419,6 +445,8 @@ public:
   TNodeI EndNI() const { return TNodeI(NodeH.EndI()); }
   /// Returns an iterator referring to the node of ID NId in the graph.
   TNodeI GetNI(const int64& NId) const { return TNodeI(NodeH.GetI(NId)); }
+  /// Returns wraper for C++ range-based loops over nodes
+  TIterNode<TNGraph> GetNI() const { return TIterNode<TNGraph>(this); }
   // GetNodeC() has been commented out. It was a quick shortcut, do not use.
   //const TNode& GetNodeC(const int& NId) const { return NodeH.GetDat(NId); }
   /// Returns an ID that is larger than any node ID in the graph.
@@ -446,6 +474,8 @@ public:
   TEdgeI GetEI(const int64& EId) const; // not supported
   /// Returns an iterator referring to edge (SrcNId, DstNId) in the graph.
   TEdgeI GetEI(const int64& SrcNId, const int64& DstNId) const;
+  /// Returns wraper for C++ range-based loops over edges
+  TIterEdge<TNGraph> GetEI() const { return TIterEdge<TNGraph>(this); }
 
   /// Returns an ID of a random node in the graph.
   int64 GetRndNId(TRnd& Rnd=TInt::Rnd) { return NodeH.GetKey(NodeH.GetRndKeyId(Rnd, 0.8)); }
@@ -543,6 +573,13 @@ public:
 
     bool operator < (const TNodeI& NodeI) const { return NodeHI < NodeI.NodeHI; }
     bool operator == (const TNodeI& NodeI) const { return NodeHI == NodeI.NodeHI; }
+
+    /// Following functions are required for C++11 range loops
+    TNodeI& operator++ () { return operator++(0); }
+    bool operator != (const TNodeI& NodeI) const { return !(NodeI == *this); }
+    const TNodeI& operator*() const { return *this; }
+    TNodeI& operator*() { return *this; }
+
     /// Returns ID of the current node.
     int64 GetId() const { return NodeHI.GetDat().GetId(); }
     /// Returns degree of the current node, the sum of in-degree and out-degree.
@@ -594,6 +631,11 @@ public:
     TEdgeI& operator++ (int) { EdgeHI++; return *this; }
     bool operator < (const TEdgeI& EdgeI) const { return EdgeHI < EdgeI.EdgeHI; }
     bool operator == (const TEdgeI& EdgeI) const { return EdgeHI == EdgeI.EdgeHI; }
+    /// Following functions are required for C++11 range loops
+    TEdgeI& operator++ () { return operator++(0); }
+    bool operator != (const TEdgeI& EdgeI) const { return !(EdgeI == *this); }
+    const TEdgeI& operator*() const { return *this; }
+    TEdgeI& operator*() { return *this; }
     /// Gets edge ID.
     int64 GetId() const { return EdgeHI.GetDat().GetId(); }
     /// Gets the source of an edge.
@@ -651,6 +693,8 @@ public:
   TNodeI EndNI() const { return TNodeI(NodeH.EndI(), this); }
   /// Returns an iterator referring to the node of ID NId in the graph.
   TNodeI GetNI(const int64& NId) const { return TNodeI(NodeH.GetI(NId), this); }
+  /// Returns wraper for C++ range-based loops over nodes
+  TIterNode<TNEGraph> GetNI() const { return TIterNode<TNEGraph>(this); }
   /// Returns an ID that is larger than any node ID in the graph.
   int64 GetMxNId() const { return MxNId; }
 
@@ -676,10 +720,12 @@ public:
   TEdgeI BegEI() const { return TEdgeI(EdgeH.BegI(), this); }
   /// Returns an iterator referring to the past-the-end edge in the graph.
   TEdgeI EndEI() const { return TEdgeI(EdgeH.EndI(), this); }
-  /// Returns an iterator referring to edge with edge ID EId. 
+  /// Returns an iterator referring to edge with edge ID EId.
   TEdgeI GetEI(const int64& EId) const { return TEdgeI(EdgeH.GetI(EId), this); }
-  /// Returns an iterator referring to edge (SrcNId, DstNId) in the graph. 
+  /// Returns an iterator referring to edge (SrcNId, DstNId) in the graph.
   TEdgeI GetEI(const int64& SrcNId, const int64& DstNId) const { return GetEI(GetEId(SrcNId, DstNId)); }
+  /// Returns wraper for C++ range-based loops over edges
+  TIterEdge<TNEGraph> GetEI() const { return TIterEdge<TNEGraph>(this); }
 
   /// Returns an ID of a random node in the graph.
   int64 GetRndNId(TRnd& Rnd=TInt::Rnd) { return NodeH.GetKey(NodeH.GetRndKeyId(Rnd, 0.8)); }
@@ -766,7 +812,7 @@ public:
     TNodeI(const TNodeI& NodeI) : LeftHI(NodeI.LeftHI), RightHI(NodeI.RightHI), leftActive(NodeI.leftActive) { }
     TNodeI& operator = (const TNodeI& NodeI) { LeftHI = NodeI.LeftHI; RightHI=NodeI.RightHI; leftActive = NodeI.leftActive; return *this; }
     /// Increment iterator.
-    TNodeI& operator++ (int) { 
+    TNodeI& operator++ (int) {
     	if (leftActive){
 				if (! LeftHI.IsEnd()) {
 					LeftHI++; }
@@ -862,7 +908,7 @@ public:
   bool HasFlag(const TGraphFlag& Flag) const;
   TBPGraph& operator = (const TBPGraph& BPGraph) {
     if (this!=&BPGraph) { MxNId=BPGraph.MxNId; LeftH=BPGraph.LeftH; RightH=BPGraph.RightH; }  return *this; }
-  
+
   /// Returns the total number of nodes in the graph.
   int64 GetNodes() const { return GetLNodes() + GetRNodes(); }
   /// Returns the number of nodes on the 'left' side of the biparite graph.
@@ -925,7 +971,7 @@ public:
   TEdgeI GetEI(const int64& EId) const;
   /// Returns an iterator referring to edge (LeftNId, RightNId) in the graph. ##TBPGraph::GetEI
   TEdgeI GetEI(const int64& LeftNId, const int64& RightNId) const;
-    
+
   /// Returns an ID of a random node in the graph.
   int64 GetRndNId(TRnd& Rnd=TInt::Rnd);
   /// Returns an ID of a random 'left' node in the graph.
@@ -963,4 +1009,3 @@ public:
 namespace TSnap {
 template <> struct IsBipart<TBPGraph> { enum { Val = 1 }; };
 }
-

--- a/snap-core/gstat.h
+++ b/snap-core/gstat.h
@@ -93,7 +93,7 @@ public:
   TStr GetNm() const { return GraphNm; }
   void SetNm(const TStr& GraphName) { GraphNm=GraphName; }
   int GetTime(const TTmUnit& TimeUnit) const { return Time.GetInUnits(TimeUnit); }
-  
+
   int64 GetVals() const { return ValStatH.Len(); }
   bool HasVal(const TGStatVal& StatVal) const;
   double GetVal(const TGStatVal& StatVal) const;
@@ -217,7 +217,7 @@ public:
 // Implementation
 template <class PGraph>
 void TGStat::TakeStat(const PGraph& Graph, const TSecTm& _Time, TFSet StatFSet, const TStr& GraphName) {
-  printf("**TakeStat:  G(%s, %s)\n", TInt64::GetStr(Graph->GetNodes()).GetCStr(), TInt64::GetStr(Graph->GetEdges()).GetCStr());
+  printf("**TakeStat:  G(%s, %s)\n", TInt64::GetStr(Graph->GetNodes()).CStr(), TInt64::GetStr(Graph->GetEdges()).CStr());
   TExeTm ExeTm, FullTm;
   Time = _Time;
   GraphNm = GraphName;
@@ -333,7 +333,7 @@ void TGStat::TakeDiam(const PGraph& Graph, TFSet StatFSet, const bool& IsMxWcc) 
   TExeTm ExeTm;
   if (! IsMxWcc) {
     if (StatFSet.In(gsvFullDiam) || StatFSet.In(gsvEffDiam) || StatFSet.In(gsdHops)) {
-      printf("anf:%sruns...", TInt64::GetStr(NDiamRuns).GetCStr()); }
+      printf("anf:%sruns...", TInt64::GetStr(NDiamRuns).CStr()); }
     //bool Line=false;
     if (StatFSet.In(gsvEffDiam) || StatFSet.In(gsdHops)) {
       TMom DiamMom;  ExeTm.Tick();

--- a/snap-core/gviz.cpp
+++ b/snap-core/gviz.cpp
@@ -36,9 +36,8 @@ TStr GVizGetLayoutStr(const TGVizLayout& Layout) {
     case gvlSfdp: return "sfdp";
     default: Fail;
   }
-  return TStr::GetNullStr();
+  return TStr();
 }
 
 } // namespace TSnapDetail
 } // namespace TSnap
-

--- a/snap-core/mmnet.cpp
+++ b/snap-core/mmnet.cpp
@@ -55,7 +55,7 @@ int64 TModeNet::AddNeighbor(const int64& NId, const int64& EId, bool outEdge, co
     AddNbrType(CrossName, sameMode, isDir);
   }
   TStr Name = GetNeighborCrossName(CrossName, outEdge, sameMode, isDir);
-  return AppendIntVAttrDatN(NId, EId, Name); 
+  return AppendIntVAttrDatN(NId, EId, Name);
 }
 
 int64 TModeNet::DelNeighbor(const int64& NId, const int64& EId, bool outEdge, const TStr& CrossName, const bool sameMode, bool isDir){
@@ -102,7 +102,7 @@ int64 TModeNet::AddNbrType(const TStr& CrossName, const bool sameMode, bool isDi
   bool hasSingleVector = (!isDir || !sameMode);
   NeighborTypes.AddDat(CrossName, hasSingleVector);
   // add crossnet attr type
-  if (hasSingleVector) { 
+  if (hasSingleVector) {
     AddIntVAttrN(CrossName);
   } else { // directed and same mode, need :SRC and :DST distinction
     AddIntVAttrN(CrossName + ":SRC");
@@ -129,7 +129,7 @@ int64 TModeNet::DelNbrType(const TStr& CrossName) {
 }
 
 void TModeNet::GetNeighborsByCrossNet(const int64& NId, TStr& Name, TInt64V& Neighbors, const bool isOutEId) const{
-  IAssertR(NeighborTypes.IsKey(Name), TStr::Fmt("Cross Type does not exist: %s", Name.GetCStr()));
+  IAssertR(NeighborTypes.IsKey(Name), TStr::Fmt("Cross Type does not exist: %s", Name.CStr()));
   TBool hasSingleVector = NeighborTypes.GetDat(Name);
   if (hasSingleVector) {
     Neighbors = GetIntVAttrDatN(NId, Name);
@@ -154,7 +154,7 @@ void TModeNet::CopyNodesWithoutNeighbors(const TModeNet& Src, TModeNet& Dst, con
     CopyAllSAttrN(Id, atStr, Src, Dst);
   }
 
-  // copy all non-IntV dense attributes 
+  // copy all non-IntV dense attributes
   for (TStrIntPr64H::TIter it = Src.KeyToIndexTypeN.BegI(); it < Src.KeyToIndexTypeN.EndI(); it++) {
     const TStr& AttrName = it.GetKey();
     TInt64 AttrType = it.GetDat().GetVal1();
@@ -165,12 +165,12 @@ void TModeNet::CopyNodesWithoutNeighbors(const TModeNet& Src, TModeNet& Dst, con
         Dst.AddIntAttrDatN(Id, Src.VecOfIntVecsN[AttrIndex][Src.NodeH.GetKeyId(Id)], AttrName);
       } else if (AttrType == FltType) {
         Dst.AddFltAttrDatN(Id, Src.VecOfFltVecsN[AttrIndex][Src.NodeH.GetKeyId(Id)], AttrName);
-      } else if (AttrType == StrType) {  
+      } else if (AttrType == StrType) {
         Dst.AddStrAttrDatN(Id, Src.VecOfStrVecsN[AttrIndex][Src.NodeH.GetKeyId(Id)], AttrName);
       }
     }
   }
-  
+
   // fetch names of all non-crossnet intv attrs, then copy values into Dst
   TStr64V CNAttrNames;
   Src.GetNeighborCrossNames(CNAttrNames);
@@ -235,7 +235,7 @@ void TModeNet::RemoveCrossNets(TModeNet& Result, TStr64V& CrossNets) {
     } else {
       TStr WithoutSuffix = AttrName;
       bool removeSuffix = false;
-      if (AttrName.IsSuffix(":SRC") || AttrName.IsSuffix(":DST")) {
+      if (AttrName.EndsWith(":SRC") || AttrName.EndsWith(":DST")) {
         WithoutSuffix = AttrName.GetSubStr(0, AttrName.Len()-5);
         removeSuffix = true;
       }
@@ -253,7 +253,7 @@ void TModeNet::RemoveCrossNets(TModeNet& Result, TStr64V& CrossNets) {
             THash<TInt64, TInt64V, int64>& Attrs = VecOfIntHashVecsN[AttrIndex];
             Result.AddIntVAttrByHashN(AttrName, Attrs);
           }
-          
+
         }
       } else {
         TInt location = CheckDenseOrSparseN(AttrName);
@@ -310,9 +310,9 @@ void TCrossNet::Clr() {
   FltDefaultsE.Clr();
   VecOfIntVecsE.Clr();
   VecOfStrVecsE.Clr();
-  VecOfFltVecsE.Clr(); 
+  VecOfFltVecsE.Clr();
   Net->ClrNbr(Mode1, CrossNetId, true, Mode1==Mode2, IsDirect.Val);
-  Net->ClrNbr(Mode2, CrossNetId, false, Mode1==Mode2, IsDirect.Val); 
+  Net->ClrNbr(Mode2, CrossNetId, false, Mode1==Mode2, IsDirect.Val);
 }
 
 int64 TCrossNet::AddEdge(const int64& sourceNId, const int64& destNId, int64 EId){
@@ -351,9 +351,9 @@ int64 TCrossNet::AddEdge(const int64& sourceNId, const int64& destNId, int64 EId
     TVec<TStr, int64>& StrVec = VecOfStrVecsE[i];
     int64 KeyId = CrossH.GetKeyId(EId);
     if (StrVec.Len() > KeyId) {
-      StrVec[KeyId] = TStr::GetNullStr();
+      StrVec[KeyId] = TStr();
     } else {
-      StrVec.Ins(KeyId, TStr::GetNullStr());
+      StrVec.Ins(KeyId, TStr());
     }
   }
   TVec<TStr, int64> DefStrVec = TVec<TStr, int64>();
@@ -397,7 +397,7 @@ int64 TCrossNet::DelEdge(const int64& EId) {
   }
   for (i = 0; i < VecOfStrVecsE.Len(); i++) {
     TVec<TStr, int64>& StrVec = VecOfStrVecsE[i];
-    StrVec[CrossH.GetKeyId(EId)] =  TStr::GetNullStr();
+    StrVec[CrossH.GetKeyId(EId)] =  TStr();
   }
   for (i = 0; i < VecOfFltVecsE.Len(); i++) {
     TVec<TFlt, int64>& FltVec = VecOfFltVecsE[i];
@@ -425,7 +425,7 @@ void TCrossNet::AttrNameEI(const TInt64& EId, TStrIntPr64H::TIter CrossHI, TStr6
       Names.Add(CrossHI.GetKey());
     }
     CrossHI++;
-  }  
+  }
 }
 
 void TCrossNet::AttrValueEI(const TInt64& EId, TStrIntPr64H::TIter CrossHI, TStr64V& Values) const {
@@ -445,7 +445,7 @@ void TCrossNet::IntAttrNameEI(const TInt64& EId, TStrIntPr64H::TIter CrossHI, TS
       Names.Add(CrossHI.GetKey());
     }
     CrossHI++;
-  }  
+  }
 }
 
 void TCrossNet::IntAttrValueEI(const TInt64& EId, TStrIntPr64H::TIter CrossHI, TInt64V& Values) const {
@@ -456,7 +456,7 @@ void TCrossNet::IntAttrValueEI(const TInt64& EId, TStrIntPr64H::TIter CrossHI, T
       Values.Add(val);
     }
     CrossHI++;
-  }  
+  }
 }
 
 void TCrossNet::StrAttrNameEI(const TInt64& EId, TStrIntPr64H::TIter CrossHI, TStr64V& Names) const {
@@ -466,7 +466,7 @@ void TCrossNet::StrAttrNameEI(const TInt64& EId, TStrIntPr64H::TIter CrossHI, TS
       Names.Add(CrossHI.GetKey());
     }
     CrossHI++;
-  }  
+  }
 }
 
 void TCrossNet::StrAttrValueEI(const TInt64& EId, TStrIntPr64H::TIter CrossHI, TStr64V& Values) const {
@@ -477,7 +477,7 @@ void TCrossNet::StrAttrValueEI(const TInt64& EId, TStrIntPr64H::TIter CrossHI, T
       Values.Add(val);
     }
     CrossHI++;
-  }  
+  }
 }
 
 void TCrossNet::FltAttrNameEI(const TInt64& EId, TStrIntPr64H::TIter CrossHI, TStr64V& Names) const {
@@ -487,7 +487,7 @@ void TCrossNet::FltAttrNameEI(const TInt64& EId, TStrIntPr64H::TIter CrossHI, TS
       Names.Add(CrossHI.GetKey());
     }
     CrossHI++;
-  }  
+  }
 }
 
 void TCrossNet::FltAttrValueEI(const TInt64& EId, TStrIntPr64H::TIter CrossHI, TFlt64V& Values) const {
@@ -498,7 +498,7 @@ void TCrossNet::FltAttrValueEI(const TInt64& EId, TStrIntPr64H::TIter CrossHI, T
       Values.Add(val);
     }
     CrossHI++;
-  }  
+  }
 }
 
 bool TCrossNet::IsFltAttrE(const TStr& attr) {
@@ -571,7 +571,7 @@ TStr TCrossNet::GetEdgeAttrValue(const int64& EId, const TStrIntPr64H::TIter& Cr
     return (this->VecOfFltVecsE.GetVal(
     this->KeyToIndexTypeE.GetDat(CrossHI.GetKey()).Val2).GetVal(CrossH.GetKeyId(EId))).GetStr();
   }
-  return TStr::GetNullStr();
+  return TStr();
 }
 
 int64 TCrossNet::AddIntAttrDatE(const int64& EId, const TInt64& value, const TStr& attr) {
@@ -618,7 +618,7 @@ int64 TCrossNet::AddStrAttrDatE(const int64& EId, const TStr& value, const TStr&
     VecOfStrVecsE.Add(NewVec);
   }
   return 0;
-} 
+}
 
 int64 TCrossNet::AddFltAttrDatE(const int64& EId, const TFlt& value, const TStr& attr) {
   int64 i;
@@ -740,7 +740,7 @@ int64 TCrossNet::DelAttrE(const TStr& attr) {
     VecOfStrVecsE[KeyToIndexTypeE.GetDat(attr).Val2] = TVec<TStr, int64>();
     if (StrDefaultsE.IsKey(attr)) {
       StrDefaultsE.DelKey(attr);
-    }  
+    }
   } else if (vecType == FltType) {
     VecOfFltVecsE[KeyToIndexTypeE.GetDat(attr).Val2] = TVec<TFlt, int64>();
     if (FltDefaultsE.IsKey(attr)) {
@@ -937,7 +937,7 @@ TCrossNet& TMMNet::GetCrossNetById(const TInt64& CrossId) const{
 int64 TMMNet::AddMode(const TStr& ModeName, const TInt64& ModeId, const TModeNet& ModeNet) {
   ModeIdToNameH.AddDat(ModeId, ModeName);
   ModeNameToIdH.AddDat(ModeName, ModeId);
-  MxModeId = MAX(MxModeId.Val, ModeId+1); 
+  MxModeId = MAX(MxModeId.Val, ModeId+1);
 
   TModeNetH.AddDat(ModeId, ModeNet);
   TModeNetH[ModeId].SetParentPointer(this);
@@ -957,7 +957,7 @@ int64 TMMNet::CopyModeWithoutNodes(const PMMNet& Src, PMMNet& Dst, const int64& 
   TModeNet& SrcMode = Src->GetModeNetById(ModeId);
   TModeNet DstMode(ModeId);
   DstMode.KeyToIndexTypeN = SrcMode.KeyToIndexTypeN; DstMode.IntDefaultsN = SrcMode.IntDefaultsN;
-  DstMode.StrDefaultsN = SrcMode.StrDefaultsN; DstMode.FltDefaultsN = SrcMode.FltDefaultsN; 
+  DstMode.StrDefaultsN = SrcMode.StrDefaultsN; DstMode.FltDefaultsN = SrcMode.FltDefaultsN;
   DstMode.VecOfIntVecsN = SrcMode.VecOfIntVecsN; DstMode.VecOfStrVecsN = SrcMode.VecOfStrVecsN;
   DstMode.VecOfFltVecsN = SrcMode.VecOfFltVecsN; DstMode.VecOfIntVecVecsN = SrcMode.VecOfIntVecVecsN;
   DstMode.DelAllAttrDatN();
@@ -968,7 +968,7 @@ int64 TMMNet::CopyModeWithoutNodes(const PMMNet& Src, PMMNet& Dst, const int64& 
     DstMode.DelAttrN(CNAttrNames[i]);
   }
 
-  DstMode.SetParentPointer(&*Dst); 
+  DstMode.SetParentPointer(&*Dst);
   Dst->TModeNetH.AddDat(ModeId, DstMode);
   return ModeId;
 }
@@ -1020,7 +1020,7 @@ int64 TMMNet::SplitCrossNetByStrAttr(const int64& CrossId, const TStr& AttrName,
   THash<TStr, TInt64V> NewNets; // attr val -> all eids with this attr value
   for (TCrossNet::TCrossEdgeI EI = CN.BegEdgeI(); EI < CN.EndEdgeI(); EI++) {
     TStr Label = CN.GetStrAttrDatE(EI, AttrName);
-    if (CrossNameToIdH.IsKey(Label)) { return -3; } // creating new crossnet with label value would interfere with existing crossnet name    
+    if (CrossNameToIdH.IsKey(Label)) { return -3; } // creating new crossnet with label value would interfere with existing crossnet name
     if (!NewNets.IsKey(Label)) { NewNets.AddDat(Label, TInt64V()); }
     NewNets.GetDat(Label).Add(EI.GetId());
   }
@@ -1032,7 +1032,7 @@ int64 TMMNet::SplitCrossNetByStrAttr(const int64& CrossId, const TStr& AttrName,
     TCrossNet& NewNet = GetCrossNetById(AddCrossNet(mid1, mid2, Label, directed));
 
     // copy all attr indexing and default info to new CN without any edges
-    NewNet.KeyToIndexTypeE = CN.KeyToIndexTypeE; 
+    NewNet.KeyToIndexTypeE = CN.KeyToIndexTypeE;
     NewNet.IntDefaultsE = CN.IntDefaultsE; NewNet.FltDefaultsE = CN.FltDefaultsE; NewNet.StrDefaultsE = CN.StrDefaultsE;
     NewNet.VecOfIntVecsE = CN.VecOfIntVecsE; NewNet.VecOfFltVecsE = CN.VecOfFltVecsE; NewNet.VecOfStrVecsE = CN.VecOfStrVecsE;
     NewNet.DelAllAttrDatE();
@@ -1135,7 +1135,7 @@ void TMMNet::ValidateCrossNetMetapaths(const int64& StartModeId, const TInt64V& 
       const TCrossNet& CNij = GetCrossNetById(CNij_Id);
 
       TBool predicate, orientation;
-      TStr assertmsg;      
+      TStr assertmsg;
       if (CNij.IsDirected()) {
         orientation = true;
         if (j == 0) {
@@ -1164,19 +1164,19 @@ void TMMNet::ValidateCrossNetMetapaths(const int64& StartModeId, const TInt64V& 
           predicate = (CNij.GetMode1() == CNij_PredDst || CNij.GetMode2() == CNij_PredDst);
           orientation = (CNij.GetMode1() == CNij_PredDst);
           assertmsg = TStr::Fmt("Neither Mode1 %d nor Mode2 %d of Metapaths[%d][%d] (crossnet id %d, undirected) matches "
-                                "Metapaths[%d][%d]'s destination mode %d", CNij.GetMode1(), CNij.GetMode2(), i, j, 
+                                "Metapaths[%d][%d]'s destination mode %d", CNij.GetMode1(), CNij.GetMode2(), i, j,
                                 CNij_Id.Val, i, j-1, CNij_PredDst.Val);
         }
       }
-      IAssertR(predicate, assertmsg);            
+      IAssertR(predicate, assertmsg);
       OriV.Add(orientation);
-    }    
+    }
   }
 
   // Ensure all nodes in StartNodeIds exist in the given mode
   TModeNet& StartMode = GetModeNetById(StartModeId);
   for (TInt64V::TIter it = StartNodeIds.BegI(); it < StartNodeIds.EndI(); it++) {
-    IAssertR(StartMode.IsNode(*it), TStr::Fmt("Node with id %d does not exist in starting mode with id %d", it->Val, 
+    IAssertR(StartMode.IsNode(*it), TStr::Fmt("Node with id %d does not exist in starting mode with id %d", it->Val,
              StartModeId));
   }
 }
@@ -1203,7 +1203,7 @@ PMMNet TMMNet::GetSubgraphByCrossNetMetapaths(const int64& StartModeId, const TI
       TInt64 CNId = Metapaths[i][j];
       TStr CNName = GetCrossName(CNId);
       TCrossNet& CN = GetCrossNetById(CNId);
-      
+
       // create copy of the metapath crossnet and its destination mode, determined by CrossOrientations
       TInt64 SrcId = (CrossOrientations[i][j].Val ? CN.GetMode1() : CN.GetMode2());
       TInt64 DstId = (CrossOrientations[i][j].Val ? CN.GetMode2() : CN.GetMode1());
@@ -1212,15 +1212,15 @@ PMMNet TMMNet::GetSubgraphByCrossNetMetapaths(const int64& StartModeId, const TI
       TModeNet& DstMode = GetModeNetById(DstId), & DstMode_Copy = Result->GetModeNetById(DstId);
       TMMNet::CopyCrossNetWithoutEdges(this, Result, CNId);
       TCrossNet& CN_Copy = Result->GetCrossNetById(CNId);
-      
+
       // get nodes and edges to add to mode and crossnet
       for (TInt64Set::TIter SrcNIt = ActiveNodes.BegI(); SrcNIt < ActiveNodes.EndI(); SrcNIt++) {
         TInt64 SrcNId = *SrcNIt;
         TInt64V CNNeighboringEdges;
         SrcMode.GetNeighborsByCrossNet(SrcNId, CNName, CNNeighboringEdges, true);
-        for (TInt64V::TIter EdgeIt = CNNeighboringEdges.BegI(); EdgeIt < CNNeighboringEdges.EndI(); EdgeIt++) {          
+        for (TInt64V::TIter EdgeIt = CNNeighboringEdges.BegI(); EdgeIt < CNNeighboringEdges.EndI(); EdgeIt++) {
           const TCrossNet::TCrossEdge& edge = CN.GetEdge(*EdgeIt);
-          
+
           // If the crossnet is undirected, this edge may have the current node as the src type or dst type.
           // Therefore find the endpoint that matches SrcNId and visit the other endpoint.
           TInt64 DstNId = (edge.GetSrcNId() == SrcNId ? edge.GetDstNId() : edge.GetSrcNId());
@@ -1228,9 +1228,9 @@ PMMNet TMMNet::GetSubgraphByCrossNetMetapaths(const int64& StartModeId, const TI
           EdgesToAdd.Add(*EdgeIt);
         }
       }
-      
+
       // copy nodes and edges that were discovered
-      TInt64V temp; 
+      TInt64V temp;
       NodesToAdd.GetKeyV(temp);
       TModeNet::CopyNodesWithoutNeighbors(DstMode, DstMode_Copy, temp);
       TCrossNet::CopyEdges(CN, CN_Copy, EdgesToAdd);
@@ -1411,7 +1411,7 @@ PNEANet TMMNet::ToNetwork2(TInt64V& CrossNetTypes, TIntStrPr64VH& NodeAttrMap, T
   NewNet->AddIntAttrN(TStr("Id"));
   NewNet->AddIntAttrE(TStr("CrossNet"));
   NewNet->AddIntAttrE(TStr("Id"));
-  
+
   //Add nodes and edges
   for (int64 i = 0; i < CrossNetTypes.Len(); i++) {
     TCrossNet& CrossNet = GetCrossNetById(CrossNetTypes[i]);
@@ -1430,7 +1430,7 @@ PNEANet TMMNet::ToNetwork2(TInt64V& CrossNetTypes, TIntStrPr64VH& NodeAttrMap, T
     TStrPr64V Mode2Attrs;
     if (NodeAttrMap.IsKey(Mode2)) {
       Mode2Attrs = NodeAttrMap.GetDat(Mode2);
-    } 
+    }
     Modes.AddKey(Mode1);
     Modes.AddKey(Mode2);
     bool isDirected = CrossNet.IsDirected();
@@ -1498,7 +1498,7 @@ PNEANet TMMNet::GetMetagraph() {
   Result->AddIntAttrE("Weight");
   Result->AddIntAttrE("Directed", true);
   Result->AddIntAttrE("Reverse", -1);
-  
+
   for (TModeNetI modeit = BegModeNetI(); modeit < EndModeNetI(); modeit++) {
     TInt64 ModeId = modeit.GetModeId();
     TStr ModeName = modeit.GetModeName();
@@ -1557,7 +1557,7 @@ void TMMNet::GetPartitionRanges(TIntPr64V& Partitions, const TInt64& NumPartitio
 
 #ifdef GCC_ATOMIC
 PNEANetMP TMMNet::ToNetworkMP(TStr64V& CrossNetNames) {
- 
+
   TStrInt64H CrossNetStart;
   THashSet<TInt64, int64> ModeSet;
   int64 offset = 0;
@@ -1601,7 +1601,7 @@ PNEANetMP TMMNet::ToNetworkMP(TStr64V& CrossNetNames) {
       TInt64 CurrEnd = NodePartitions[i].GetVal2();
       curr_nid = offset + CurrStart;
       for (int64 idx = CurrStart; idx < CurrEnd ; idx++) {
-  
+
         int64 n_i = KeyIds[idx];
         if (ModeNet.IsNode(n_i)) {
           //Collect neighbors
@@ -1657,7 +1657,7 @@ PNEANetMP TMMNet::ToNetworkMP(TStr64V& CrossNetNames) {
         }
       }
     }
-  
+
     offset += KeyIds.Len();
   }
   NewNet->SetNodes(offset);

--- a/snap-core/mmnet.h
+++ b/snap-core/mmnet.h
@@ -81,7 +81,7 @@ public:
   void Clr();
 
 
-  TModeNet& operator = (const TModeNet& Graph) { 
+  TModeNet& operator = (const TModeNet& Graph) {
     if (this!=&Graph) {
       MxNId=Graph.MxNId; MxEId=Graph.MxEId; NodeH=Graph.NodeH; EdgeH=Graph.EdgeH;
       KeyToIndexTypeN=Graph.KeyToIndexTypeN; KeyToIndexTypeE=Graph.KeyToIndexTypeE;
@@ -89,11 +89,11 @@ public:
       IntDefaultsN=Graph.IntDefaultsN; IntDefaultsE=Graph.IntDefaultsE; StrDefaultsN=Graph.StrDefaultsN; StrDefaultsE=Graph.StrDefaultsE;
       FltDefaultsN=Graph.FltDefaultsN; FltDefaultsE=Graph.FltDefaultsE; VecOfIntVecsN=Graph.VecOfIntVecsN; VecOfIntVecsE=Graph.VecOfIntVecsE;
       VecOfStrVecsN=Graph.VecOfStrVecsN; VecOfStrVecsE=Graph.VecOfStrVecsE; VecOfFltVecsN=Graph.VecOfFltVecsN; VecOfFltVecsE=Graph.VecOfFltVecsE;
-      VecOfIntVecVecsN=Graph.VecOfIntVecVecsN; VecOfIntVecVecsE=Graph.VecOfIntVecVecsE; 
+      VecOfIntVecVecsN=Graph.VecOfIntVecVecsN; VecOfIntVecVecsE=Graph.VecOfIntVecVecsE;
       VecOfIntHashVecsN = Graph.VecOfIntHashVecsN; VecOfIntHashVecsE = Graph.VecOfIntHashVecsE; SAttrN=Graph.SAttrN; SAttrE=Graph.SAttrE;
       ModeId=Graph.ModeId; MMNet=Graph.MMNet; NeighborTypes=Graph.NeighborTypes;
     }
-    return *this; 
+    return *this;
   }
 
 private:
@@ -280,7 +280,7 @@ public:
   TCrossNet(TSIn& SIn) : CrossH(SIn), MxEId(SIn), Mode1(SIn), Mode2(SIn), IsDirect(SIn), CrossNetId(SIn), Net(),
     KeyToIndexTypeE(SIn), IntDefaultsE(SIn), StrDefaultsE(SIn), FltDefaultsE(SIn), VecOfIntVecsE(SIn), VecOfStrVecsE(SIn), VecOfFltVecsE(SIn) {}
   TCrossNet(const TCrossNet& OtherTCrossNet) : CrossH(OtherTCrossNet.CrossH), MxEId(OtherTCrossNet.MxEId), Mode1(OtherTCrossNet.Mode1),
-    Mode2(OtherTCrossNet.Mode2), IsDirect(OtherTCrossNet.IsDirect), CrossNetId(OtherTCrossNet.CrossNetId),Net(OtherTCrossNet.Net), KeyToIndexTypeE(OtherTCrossNet.KeyToIndexTypeE), 
+    Mode2(OtherTCrossNet.Mode2), IsDirect(OtherTCrossNet.IsDirect), CrossNetId(OtherTCrossNet.CrossNetId),Net(OtherTCrossNet.Net), KeyToIndexTypeE(OtherTCrossNet.KeyToIndexTypeE),
     IntDefaultsE(OtherTCrossNet.IntDefaultsE), StrDefaultsE(OtherTCrossNet.StrDefaultsE), FltDefaultsE(OtherTCrossNet.FltDefaultsE), VecOfIntVecsE(OtherTCrossNet.VecOfIntVecsE),
     VecOfStrVecsE(OtherTCrossNet.VecOfStrVecsE), VecOfFltVecsE(OtherTCrossNet.VecOfFltVecsE) {}
 
@@ -307,7 +307,7 @@ private:
   /// Gets Int edge attribute val.  If not a proper attr, return default.
   TInt64 GetIntAttrDefaultE(const TStr& attribute) const { return IntDefaultsE.IsKey(attribute) ? IntDefaultsE.GetDat(attribute) : (TInt64) TInt64::Mn; }
   /// Gets Str edge attribute val.  If not a proper attr, return default.
-  TStr GetStrAttrDefaultE(const TStr& attribute) const { return StrDefaultsE.IsKey(attribute) ? StrDefaultsE.GetDat(attribute) : (TStr) TStr::GetNullStr(); }
+  TStr GetStrAttrDefaultE(const TStr& attribute) const { return StrDefaultsE.IsKey(attribute) ? StrDefaultsE.GetDat(attribute) : (TStr) TStr(); }
   /// Gets Flt edge attribute val.  If not a proper attr, return default.
   TFlt GetFltAttrDefaultE(const TStr& attribute) const { return FltDefaultsE.IsKey(attribute) ? FltDefaultsE.GetDat(attribute) : (TFlt) TFlt::Mn; }
   int64 GetAttrTypeE(const TStr& attr) const;
@@ -336,7 +336,7 @@ public:
   /// Gets the id of the dst mode.
   int64 GetMode2() const {return Mode2; }
   /// Saves the TCrossNet to the binary stream.
-  void Save(TSOut& SOut) const { CrossH.Save(SOut); MxEId.Save(SOut); Mode1.Save(SOut); Mode2.Save(SOut); IsDirect.Save(SOut); CrossNetId.Save(SOut); 
+  void Save(TSOut& SOut) const { CrossH.Save(SOut); MxEId.Save(SOut); Mode1.Save(SOut); Mode2.Save(SOut); IsDirect.Save(SOut); CrossNetId.Save(SOut);
     KeyToIndexTypeE.Save(SOut); IntDefaultsE.Save(SOut); StrDefaultsE.Save(SOut); FltDefaultsE.Save(SOut); VecOfIntVecsE.Save(SOut);
     VecOfStrVecsE.Save(SOut); VecOfFltVecsE.Save(SOut); }
   /// Load network from shared memory stream
@@ -453,13 +453,13 @@ public:
   }
 
   /// Deletes the edge attribute for NodeI.
-  int64 DelAttrDatE(const TCrossEdgeI& EdgeI, const TStr& attr) { return DelAttrDatE(EdgeI.GetId(), attr); } 
-  int64 DelAttrDatE(const int64& EId, const TStr& attr); 
+  int64 DelAttrDatE(const TCrossEdgeI& EdgeI, const TStr& attr) { return DelAttrDatE(EdgeI.GetId(), attr); }
+  int64 DelAttrDatE(const int64& EId, const TStr& attr);
 
   /// Adds a new Int edge attribute to the hashmap.
   int64 AddIntAttrE(const TStr& attr, TInt64 defaultValue=TInt64::Mn);
   /// Adds a new Str edge attribute to the hashmap.
-  int64 AddStrAttrE(const TStr& attr, TStr defaultValue=TStr::GetNullStr());
+  int64 AddStrAttrE(const TStr& attr, TStr defaultValue=TStr());
   /// Adds a new Flt edge attribute to the hashmap.
   int64 AddFltAttrE(const TStr& attr, TFlt defaultValue=TFlt::Mn);
 
@@ -564,9 +564,9 @@ public:
 
 private:
   /// Keeps track of the max mode id.
-  TInt64 MxModeId; 
+  TInt64 MxModeId;
   /// Keeps track of the max crossnet id
-  TInt64 MxCrossNetId; 
+  TInt64 MxCrossNetId;
   THash<TInt64, TModeNet, int64> TModeNetH;
   THash<TInt64, TCrossNet, int64> TCrossNetH;
 
@@ -596,9 +596,9 @@ private:
   void LoadNetworkShM(TShMIn& ShMIn);
 public:
   TMMNet() : CRef(), MxModeId(0), MxCrossNetId(0), TModeNetH(), TCrossNetH(), ModeIdToNameH(), ModeNameToIdH(), CrossIdToNameH(), CrossNameToIdH() {}
-  TMMNet(const TMMNet& OtherTMMNet) : MxModeId(OtherTMMNet.MxModeId), MxCrossNetId(OtherTMMNet.MxCrossNetId), TModeNetH(OtherTMMNet.TModeNetH), 
+  TMMNet(const TMMNet& OtherTMMNet) : MxModeId(OtherTMMNet.MxModeId), MxCrossNetId(OtherTMMNet.MxCrossNetId), TModeNetH(OtherTMMNet.TModeNetH),
     TCrossNetH(OtherTMMNet.TCrossNetH), ModeIdToNameH(OtherTMMNet.ModeIdToNameH), ModeNameToIdH(OtherTMMNet.ModeNameToIdH), CrossIdToNameH(OtherTMMNet.CrossIdToNameH), CrossNameToIdH(OtherTMMNet.CrossNameToIdH) {}
-  TMMNet(TSIn& SIn) : MxModeId(SIn), MxCrossNetId(SIn), TModeNetH(SIn), TCrossNetH(SIn), ModeIdToNameH(SIn), ModeNameToIdH(SIn), CrossIdToNameH(SIn), CrossNameToIdH(SIn) { 
+  TMMNet(TSIn& SIn) : MxModeId(SIn), MxCrossNetId(SIn), TModeNetH(SIn), TCrossNetH(SIn), ModeIdToNameH(SIn), ModeNameToIdH(SIn), CrossIdToNameH(SIn), CrossNameToIdH(SIn) {
     for (THash<TInt64, TModeNet, int64>::TIter it = TModeNetH.BegI(); it < TModeNetH.EndI(); it++) {
       it.GetDat().SetParentPointer(this);
     }
@@ -611,7 +611,7 @@ public:
   /// Adds a mode to the multimodal network.
   int64 AddModeNet(const TStr& ModeName);
   /// Deletes a mode from the multimodal network.
-  int64 DelModeNet(const TInt64& ModeId); 
+  int64 DelModeNet(const TInt64& ModeId);
   int64 DelModeNet(const TStr& ModeName);
   /// Returns true if and only if there is a crossnet with the given id in the multimodal network.
   bool IsCrossNet(const int64& CNId) { return TCrossNetH.IsKey(CNId); }
@@ -623,12 +623,12 @@ public:
   int64 DelCrossNet(const TStr& CrossNet);
 
   /// Saves the TMMNet to binary stream.
-  void Save(TSOut& SOut) const {MxModeId.Save(SOut); MxCrossNetId.Save(SOut); TModeNetH.Save(SOut); 
+  void Save(TSOut& SOut) const {MxModeId.Save(SOut); MxCrossNetId.Save(SOut); TModeNetH.Save(SOut);
     TCrossNetH.Save(SOut); ModeIdToNameH.Save(SOut); ModeNameToIdH.Save(SOut); CrossIdToNameH.Save(SOut);
     CrossNameToIdH.Save(SOut); }
   /// Loads the TMMNet from binary stream.
   static PMMNet Load(TSIn& SIn) { return PMMNet(new TMMNet(SIn)); }
-  /// Loads network from mmapped shared memory. 
+  /// Loads network from mmapped shared memory.
   static PMMNet LoadShM(TShMIn& ShMIn) {
     TMMNet* Network = new TMMNet();
     Network->LoadNetworkShM(ShMIn);
@@ -645,11 +645,11 @@ public:
   /// Gets the mode id from the mode name.
   int64 GetModeId(const TStr& ModeName) const { if (ModeNameToIdH.IsKey(ModeName)) { return ModeNameToIdH.GetDat(ModeName); } else { return -1; }  }
   /// Gets the mode name from the mode id.
-  TStr GetModeName(const TInt64& ModeId) const { if (ModeIdToNameH.IsKey(ModeId)) { return ModeIdToNameH.GetDat(ModeId); } else {return TStr::GetNullStr();} }
+  TStr GetModeName(const TInt64& ModeId) const { if (ModeIdToNameH.IsKey(ModeId)) { return ModeIdToNameH.GetDat(ModeId); } else {return TStr();} }
   /// Gets the crossnet id from the crossnet name.
   int64 GetCrossId(const TStr& CrossName) const { if (CrossNameToIdH.IsKey(CrossName)) { return CrossNameToIdH.GetDat(CrossName); } else { return -1; }   }
   /// Gets the crossnet name from the crossnet id.
-  TStr GetCrossName(const TInt64& CrossId) const { if (CrossIdToNameH.IsKey(CrossId)) { return CrossIdToNameH.GetDat(CrossId); } else { return TStr::GetNullStr(); }  }
+  TStr GetCrossName(const TInt64& CrossId) const { if (CrossIdToNameH.IsKey(CrossId)) { return CrossIdToNameH.GetDat(CrossId); } else { return TStr(); }  }
 
   /// Gets a reference to the modenet.
   TModeNet& GetModeNetByName(const TStr& ModeName) const;
@@ -663,7 +663,7 @@ public:
   TCrossNetI GetCrossNetI(const int64& Id) const { return TCrossNetI(TCrossNetH.GetI(Id), this); }
   TCrossNetI BegCrossNetI() const { return TCrossNetI(TCrossNetH.BegI(), this); }
   TCrossNetI EndCrossNetI() const { return TCrossNetI(TCrossNetH.EndI(), this); }
- 
+
   /// Iterator over all modenets.
   TModeNetI GetModeNetI(const int64& Id) const { return TModeNetI(TModeNetH.GetI(Id), this); }
   TModeNetI BegModeNetI() const { return TModeNetI(TModeNetH.BegI(), this); }
@@ -698,7 +698,7 @@ public:
   static int64 CopyCrossNetWithoutEdges(const PMMNet& Src, PMMNet& Dst, const int64& CrossId);
   /// Gets the subnetwork reachable a set of starting nodes in a single mode and a sequence of metapaths to traverse from the starting mode. ##TMMNet::GetSubgraphByCrossNetMetapaths
   PMMNet GetSubgraphByCrossNetMetapaths(const int64& StartModeId, const TInt64V& StartNodeIds, const TVec<TInt64V>& Metapaths);
-  
+
   /// Converts multimodal network to TNEANet; as attr names can collide, AttrMap specifies the (Mode/Cross Id, old att name, new attr name)
   PNEANet ToNetwork(TInt64V& CrossNetTypes, TIntStrStrTr64V& NodeAttrMap, TVec<TTriple<TInt64, TStr, TStr>, int64 >& EdgeAttrMap);
   /// Converts multimodal network to TNEANet; as attr names can collide, AttrMap specifies the Mode/Cross Id -> vec of pairs (old att name, new attr name)
@@ -718,7 +718,7 @@ private:
   int64 AddEdgeAttributes(PNEANet& NewNet, TCrossNet& Net, TVec<TPair<TStr, TStr>, int64 >& Attrs, int64 CrossId, int64 oldId, int64 EId);
   void GetPartitionRanges(TIntPr64V& Partitions, const TInt64& NumPartitions, const TInt64& MxVal) const;
   /// Ensures the parameters of GetSubgraphByCrossNetMetapaths are valid as described in its documentation; sets orientations of undirected crossnets in CrossOrientations.
-  void ValidateCrossNetMetapaths(const int64& StartModeId, const TInt64V& StartNodeIds, const TVec<TInt64V>& Metapaths, TVec<TBoolV>& CrossOrientations); 
+  void ValidateCrossNetMetapaths(const int64& StartModeId, const TInt64V& StartNodeIds, const TVec<TInt64V>& Metapaths, TVec<TBoolV>& CrossOrientations);
 };
 
 // set flags

--- a/snap-core/network.cpp
+++ b/snap-core/network.cpp
@@ -72,7 +72,7 @@ void TNEANet::AttrNameNI(const TInt64& NId, TStrIntPr64H::TIter NodeHI, TStr64V&
       Names.Add(NodeHI.GetKey());
     }
     NodeHI++;
-  }  
+  }
 }
 
 void TNEANet::AttrValueNI(const TInt64& NId , TStrIntPr64H::TIter NodeHI, TStr64V& Values) const {
@@ -92,7 +92,7 @@ void TNEANet::IntAttrNameNI(const TInt64& NId, TStrIntPr64H::TIter NodeHI, TStr6
       Names.Add(NodeHI.GetKey());
     }
     NodeHI++;
-  }  
+  }
 }
 
 void TNEANet::IntAttrValueNI(const TInt64& NId, TStrIntPr64H::TIter NodeHI, TInt64V& Values) const {
@@ -103,7 +103,7 @@ void TNEANet::IntAttrValueNI(const TInt64& NId, TStrIntPr64H::TIter NodeHI, TInt
       Values.Add(val);
     }
     NodeHI++;
-  }  
+  }
 }
 
 void TNEANet::IntVAttrNameNI(const TInt64& NId, TStrIntPr64H::TIter NodeHI, TStr64V& Names) const {
@@ -113,7 +113,7 @@ void TNEANet::IntVAttrNameNI(const TInt64& NId, TStrIntPr64H::TIter NodeHI, TStr
       Names.Add(NodeHI.GetKey());
     }
     NodeHI++;
-  }  
+  }
 }
 
 void TNEANet::IntVAttrValueNI(const TInt64& NId, TStrIntPr64H::TIter NodeHI, TVec<TInt64V, int64>& Values) const {
@@ -144,7 +144,7 @@ void TNEANet::StrAttrNameNI(const TInt64& NId, TStrIntPr64H::TIter NodeHI, TStr6
       Names.Add(NodeHI.GetKey());
     }
     NodeHI++;
-  }  
+  }
 }
 
 void TNEANet::StrAttrValueNI(const TInt64& NId, TStrIntPr64H::TIter NodeHI, TStr64V& Values) const {
@@ -155,7 +155,7 @@ void TNEANet::StrAttrValueNI(const TInt64& NId, TStrIntPr64H::TIter NodeHI, TStr
       Values.Add(val);
     }
     NodeHI++;
-  }  
+  }
 }
 
 void TNEANet::FltAttrNameNI(const TInt64& NId, TStrIntPr64H::TIter NodeHI, TStr64V& Names) const {
@@ -165,7 +165,7 @@ void TNEANet::FltAttrNameNI(const TInt64& NId, TStrIntPr64H::TIter NodeHI, TStr6
       Names.Add(NodeHI.GetKey());
     }
     NodeHI++;
-  }  
+  }
 }
 
 void TNEANet::FltAttrValueNI(const TInt64& NId, TStrIntPr64H::TIter NodeHI, TFlt64V& Values) const {
@@ -176,7 +176,7 @@ void TNEANet::FltAttrValueNI(const TInt64& NId, TStrIntPr64H::TIter NodeHI, TFlt
       Values.Add(val);
     }
     NodeHI++;
-  }  
+  }
 }
 
 bool TNEANet::IsAttrDeletedN(const int64& NId, const TStr& attr) const {
@@ -254,7 +254,7 @@ TStr TNEANet::GetNodeAttrValue(const int64& NId, const TStrIntPr64H::TIter& Node
     return (this->VecOfFltVecsN.GetVal(
       this->KeyToIndexTypeN.GetDat(NodeHI.GetKey()).Val2).GetVal(NodeH.GetKeyId(NId))).GetStr();
   }
-  return TStr::GetNullStr();
+  return TStr();
 }
 
 void TNEANet::AttrNameEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TStr64V& Names) const {
@@ -264,7 +264,7 @@ void TNEANet::AttrNameEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TStr64V&
       Names.Add(EdgeHI.GetKey());
     }
     EdgeHI++;
-  }  
+  }
 }
 
 void TNEANet::AttrValueEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TStr64V& Values) const {
@@ -274,7 +274,7 @@ void TNEANet::AttrValueEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TStr64V
       Values.Add(GetEdgeAttrValue(EId, EdgeHI));
     }
     EdgeHI++;
-  }  
+  }
 }
 
 void TNEANet::IntAttrNameEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TStr64V& Names) const {
@@ -284,7 +284,7 @@ void TNEANet::IntAttrNameEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TStr6
       Names.Add(EdgeHI.GetKey());
     }
     EdgeHI++;
-  }  
+  }
 }
 
 void TNEANet::IntAttrValueEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TInt64V& Values) const {
@@ -295,7 +295,7 @@ void TNEANet::IntAttrValueEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TInt
       Values.Add(val);
     }
     EdgeHI++;
-  }  
+  }
 }
 
 void TNEANet::IntVAttrNameEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TStr64V& Names) const {
@@ -305,7 +305,7 @@ void TNEANet::IntVAttrNameEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TStr
       Names.Add(EdgeHI.GetKey());
     }
     EdgeHI++;
-  }  
+  }
 }
 
 void TNEANet::IntVAttrValueEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TVec<TInt64V, int64>& Values) const {
@@ -336,7 +336,7 @@ void TNEANet::StrAttrNameEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TStr6
       Names.Add(EdgeHI.GetKey());
     }
     EdgeHI++;
-  }  
+  }
 }
 
 void TNEANet::StrAttrValueEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TStr64V& Values) const {
@@ -347,7 +347,7 @@ void TNEANet::StrAttrValueEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TStr
       Values.Add(val);
     }
     EdgeHI++;
-  }  
+  }
 }
 
 void TNEANet::FltAttrNameEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TStr64V& Names) const {
@@ -357,7 +357,7 @@ void TNEANet::FltAttrNameEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TStr6
       Names.Add(EdgeHI.GetKey());
     }
     EdgeHI++;
-  }  
+  }
 }
 
 void TNEANet::FltAttrValueEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TFlt64V& Values) const {
@@ -368,7 +368,7 @@ void TNEANet::FltAttrValueEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TFlt
       Values.Add(val);
     }
     EdgeHI++;
-  }  
+  }
 }
 
 bool TNEANet::IsAttrDeletedE(const int64& EId, const TStr& attr) const {
@@ -438,7 +438,7 @@ TStr TNEANet::GetEdgeAttrValue(const int64& EId, const TStrIntPr64H::TIter& Edge
     return (this->VecOfFltVecsE.GetVal(
       this->KeyToIndexTypeE.GetDat(EdgeHI.GetKey()).Val2).GetVal(EdgeH.GetKeyId(EId))).GetStr();
   }
-  return TStr::GetNullStr();
+  return TStr();
 }
 
 int64 TNEANet::AddNode(int64 NId) {
@@ -483,14 +483,14 @@ int64 TNEANet::AddAttributes(const int64 NId) {
     TStr attr = DefIntVec[i];
     TVec<TInt64, int64>& IntVec = VecOfIntVecsN[KeyToIndexTypeN.GetDat(DefIntVec[i]).Val2];
     IntVec[NodeH.GetKeyId(NId)] = GetIntAttrDefaultN(attr);
-  } 
+  }
   for (i = 0; i < VecOfStrVecsN.Len(); i++) {
     TVec<TStr, int64>& StrVec = VecOfStrVecsN[i];
     int64 KeyId = NodeH.GetKeyId(NId);
     if (StrVec.Len() > KeyId) {
-      StrVec[KeyId] = TStr::GetNullStr();
+      StrVec[KeyId] = TStr();
     } else {
-      StrVec.Ins(KeyId, TStr::GetNullStr());
+      StrVec.Ins(KeyId, TStr());
     }
   }
   TVec<TStr, int64> DefStrVec = TVec<TStr, int64>();
@@ -545,7 +545,7 @@ void TNEANet::DelNode(const int64& NId) {
     }
     for (i = 0; i < VecOfStrVecsE.Len(); i++) {
       TVec<TStr, int64>& StrVec = VecOfStrVecsE[i];
-      StrVec[EdgeH.GetKeyId(EId)] = TStr::GetNullStr();
+      StrVec[EdgeH.GetKeyId(EId)] = TStr();
     }
     for (i = 0; i < VecOfFltVecsE.Len(); i++) {
       TVec<TFlt, int64>& FltVec = VecOfFltVecsE[i];
@@ -575,7 +575,7 @@ void TNEANet::DelNode(const int64& NId) {
     }
     for (i = 0; i < VecOfStrVecsE.Len(); i++) {
       TVec<TStr, int64>& StrVec = VecOfStrVecsE[i];
-      StrVec[EdgeH.GetKeyId(EId)] = TStr::GetNullStr();
+      StrVec[EdgeH.GetKeyId(EId)] = TStr();
     }
     for (i = 0; i < VecOfFltVecsE.Len(); i++) {
       TVec<TFlt, int64>& FltVec = VecOfFltVecsE[i];
@@ -600,7 +600,7 @@ void TNEANet::DelNode(const int64& NId) {
   }
   for (i = 0; i < VecOfStrVecsN.Len(); i++) {
     TVec<TStr, int64>& StrVec = VecOfStrVecsN[i];
-    StrVec[NodeH.GetKeyId(NId)] = TStr::GetNullStr();
+    StrVec[NodeH.GetKeyId(NId)] = TStr();
   }
   for (i = 0; i < VecOfFltVecsN.Len(); i++) {
     TVec<TFlt, int64>& FltVec = VecOfFltVecsN[i];
@@ -657,9 +657,9 @@ int64 TNEANet::AddEdge(const int64& SrcNId, const int64& DstNId, int64 EId) {
     TVec<TStr, int64>& StrVec = VecOfStrVecsE[i];
     int64 KeyId = EdgeH.GetKeyId(EId);
     if (StrVec.Len() > KeyId) {
-      StrVec[KeyId] = TStr::GetNullStr();
+      StrVec[KeyId] = TStr();
     } else {
-      StrVec.Ins(KeyId, TStr::GetNullStr());
+      StrVec.Ins(KeyId, TStr());
     }
   }
   TVec<TStr, int64> DefStrVec = TVec<TStr, int64>();
@@ -706,7 +706,7 @@ void TNEANet::DelEdge(const int64& EId) {
   }
   for (i = 0; i < VecOfStrVecsE.Len(); i++) {
     TVec<TStr, int64>& StrVec = VecOfStrVecsE[i];
-    StrVec[EdgeH.GetKeyId(EId)] = TStr::GetNullStr();
+    StrVec[EdgeH.GetKeyId(EId)] = TStr();
   }
   for (i = 0; i < VecOfFltVecsE.Len(); i++) {
     TVec<TFlt, int64>& FltVec = VecOfFltVecsE[i];
@@ -851,7 +851,7 @@ void TNEANet::Dump(FILE *OutF) const {
     StrAttrValueNI(NodeI.GetId(), StrAttrN);
     fprintf(OutF, "    nas[%s]", TInt64::GetStr(StrAttrN.Len()).CStr());
     for (int64 i = 0; i < StrAttrN.Len(); i++) {
-      fprintf(OutF, " %*s", NodePlaces, StrAttrN[i]()); }
+      fprintf(OutF, " %*s", NodePlaces, StrAttrN[i].CStr()); }
     //fprintf(OutF, "\n");
 
     TFlt64V FltAttrN;
@@ -870,19 +870,19 @@ void TNEANet::Dump(FILE *OutF) const {
     IntAttrValueEI(EdgeI.GetId(), IntAttrE);
     fprintf(OutF, "    eai[%s]", TInt64::GetStr(IntAttrE.Len()).CStr());
     for (int64 i = 0; i < IntAttrE.Len(); i++) {
-      fprintf(OutF, " %*s", EdgePlaces, TInt64::GetStr(IntAttrE[i]()).CStr()); 
+      fprintf(OutF, " %*s", EdgePlaces, TInt64::GetStr(IntAttrE[i]()).CStr());
     }
     TStr64V StrAttrE;
     StrAttrValueEI(EdgeI.GetId(), StrAttrE);
     fprintf(OutF, "    eas[%s]", TInt64::GetStr(StrAttrE.Len()).CStr());
     for (int64 i = 0; i < StrAttrE.Len(); i++) {
-      fprintf(OutF, " %*s", EdgePlaces, StrAttrE[i]()); 
+      fprintf(OutF, " %*s", EdgePlaces, StrAttrE[i].CStr());
     }
     TFlt64V FltAttrE;
     FltAttrValueEI(EdgeI.GetId(), FltAttrE);
     fprintf(OutF, "    eaf[%s]", TInt64::GetStr(FltAttrE.Len()).CStr());
     for (int64 i = 0; i < FltAttrE.Len(); i++) {
-      fprintf(OutF, " %*f", EdgePlaces, FltAttrE[i]()); 
+      fprintf(OutF, " %*f", EdgePlaces, FltAttrE[i]());
     }
     fprintf(OutF, "\n");
   }
@@ -898,19 +898,19 @@ bool TNEANet::IsEulerian(int64 *StartNId) {
     if (indeg != outdeg) {
       if (indeg - outdeg == 1) { // must be destination of path
         if (finishfound) {
-          return false; 
+          return false;
         } else {
           finishfound = true;
         }
       } else if (outdeg - indeg == 1) { // must be source of path
-        if (startfound) { 
-          return false; 
+        if (startfound) {
+          return false;
         } else {
           if (StartNId) { *StartNId = NI.GetId(); }
           startfound = true;
         }
       } else { // abs(indeg - outdeg) > 1
-        return false; 
+        return false;
       }
     }
   }
@@ -936,7 +936,7 @@ void TNEANet::AddPath(THash<TInt64, TVec<TInt64V, int64> >& AllPaths, const TInt
       }
     }
     ResultPath.Add(ToAddPath[i]);
-    CurrNId = GetEI(ToAddPath[i]).GetDstNId();    
+    CurrNId = GetEI(ToAddPath[i]).GetDstNId();
   }
 }
 
@@ -944,30 +944,30 @@ bool TNEANet::GetEulerPath(TInt64V& Path) {
   Path = TInt64V();
   int64 StartNId;
   if (!IsEulerian(&StartNId)) { return false; }
-  
+
   THash<TInt64, TInt64Set> OutboundEdges; // nodeid -> (list of outbound edges (id relative to node, not absolute eid))
   THash<TInt64, TInt64Set> SelfEdges; // nodeid -> (list of self edges (id relative to node))
   for (TNodeI NI = BegNI(); NI < EndNI(); NI++) {
     TInt64Set out, self;
-    for (int64 i = 0; i < NI.GetOutDeg(); i++) { 
+    for (int64 i = 0; i < NI.GetOutDeg(); i++) {
       TEdgeI edge = GetEI(NI.GetOutEId(i));
       if (edge.GetDstNId() == edge.GetSrcNId()) { // self edge
         self.AddKey(i);
-      } else { 
+      } else {
         out.AddKey(i);
       }
     }
     OutboundEdges.AddDat(NI.GetId(), out);
     SelfEdges.AddDat(NI.GetId(), self);
   }
-  
+
   // Use Hierholzer's algorithm to generate Euler path.
   THash<TInt64, TVec<TInt64V, int64> > Paths; // Node id -> all paths that start at this node
- 
+
   // 1. Create a set of edge-disjoint paths that span all edges of the graph.
   // All paths except possibly the first are cycles.
   bool firstpath = true;
-  while (!OutboundEdges.Empty()) { 
+  while (!OutboundEdges.Empty()) {
     TInt64V currpath;
     TInt64 PathStartNId = (firstpath ? StartNId : OutboundEdges.BegI().GetKey().Val);
     firstpath = false;
@@ -976,7 +976,7 @@ bool TNEANet::GetEulerPath(TInt64V& Path) {
     while (OutboundEdges.IsKey(currnode.GetId())) {
       TInt64Set& curroutbound = OutboundEdges.GetDat(currnode.GetId());
       TInt64Set& currself = SelfEdges.GetDat(currnode.GetId());
-      
+
       if (!currself.Empty()) { // First time visit; get self edges out of the way
         for (int i = 0; i < currself.Len(); i++) { currpath.Add(currnode.GetOutEId(currself[i])); }
         currself.Clr();
@@ -990,12 +990,12 @@ bool TNEANet::GetEulerPath(TInt64V& Path) {
       // Delete the visited edge from the node's list. If the list is empty, delete the node from OutboundEdges.
       curroutbound.DelKey(outrelid);
       if (curroutbound.Empty()) { OutboundEdges.DelKey(currnode.GetId()); }
-      currnode = GetNI(outedge.GetDstNId());      
+      currnode = GetNI(outedge.GetDstNId());
     }
     if (!Paths.IsKey(PathStartNId)) { Paths.AddKey(PathStartNId); }
-    Paths.GetDat(PathStartNId).Add(currpath); // we're stuck at the current node so we completed a path    
+    Paths.GetDat(PathStartNId).Add(currpath); // we're stuck at the current node so we completed a path
   }
-  
+
   // 2. Traverse the first/"main" path. Each time we encounter a node with a different cycle
   // starting at it, recursively add it to the result path, then continue with the main path.
   TVec<TInt64V, int64>& PathsFromStart = Paths.GetDat(StartNId);
@@ -1051,9 +1051,9 @@ int64 TNEANet::AddIntVAttrDatN(const int64& NId, const TInt64V& value, const TSt
     THash<TInt64, TInt64V, int64>& NewHash = VecOfIntHashVecsN[KeyToIndexTypeN.GetDat(attr).Val2];
     NewHash.AddDat(NodeH.GetKeyId(NId), value);
   }
-  
+
   return 0;
-} 
+}
 
 int64 TNEANet::AppendIntVAttrDatN(const int64& NId, const TInt64& value, const TStr& attr, TBool UseDense) {
   if (!IsNode(NId)) {
@@ -1075,7 +1075,7 @@ int64 TNEANet::AppendIntVAttrDatN(const int64& NId, const TInt64& value, const T
     NewHash[NodeH.GetKeyId(NId)].Add(value);
   }
   return 0;
-} 
+}
 
 int64 TNEANet::DelFromIntVAttrDatN(const int64& NId, const TInt64& value, const TStr& attr) {
   if (!IsNode(NId)) {
@@ -1099,7 +1099,7 @@ int64 TNEANet::DelFromIntVAttrDatN(const int64& NId, const TInt64& value, const 
     return -1;
   }
   return 0;
-} 
+}
 
 int64 TNEANet::AddStrAttrDatN(const int64& NId, const TStr& value, const TStr& attr) {
   int64 i;
@@ -1122,7 +1122,7 @@ int64 TNEANet::AddStrAttrDatN(const int64& NId, const TStr& value, const TStr& a
     VecOfStrVecsN.Add(NewVec);
   }
   return 0;
-} 
+}
 
 int64 TNEANet::AddFltAttrDatN(const int64& NId, const TFlt& value, const TStr& attr) {
   int64 i;
@@ -1146,7 +1146,7 @@ int64 TNEANet::AddFltAttrDatN(const int64& NId, const TFlt& value, const TStr& a
     VecOfFltVecsN.Add(NewVec);
   }
   return 0;
-} 
+}
 
 int64 TNEANet::AddIntAttrDatE(const int64& EId, const TInt64& value, const TStr& attr) {
   int64 i;
@@ -1191,7 +1191,7 @@ int64 TNEANet::AddIntVAttrDatE(const int64& EId, const TInt64V& value, const TSt
     NewHash.AddDat(EdgeH.GetKeyId(EId), value);
   }
   return 0;
-} 
+}
 
 int64 TNEANet::AppendIntVAttrDatE(const int64& EId, const TInt64& value, const TStr& attr, TBool UseDense) {
   if (!IsNode(EId)) {
@@ -1233,7 +1233,7 @@ int64 TNEANet::AddStrAttrDatE(const int64& EId, const TStr& value, const TStr& a
     VecOfStrVecsE.Add(NewVec);
   }
   return 0;
-} 
+}
 
 int64 TNEANet::AddFltAttrDatE(const int64& EId, const TFlt& value, const TStr& attr) {
   int64 i;
@@ -1360,7 +1360,7 @@ int64 TNEANet::DelAttrDatN(const int64& NId, const TStr& attr) {
   }
   return 0;
 }
-             
+
 int64 TNEANet::DelAttrDatE(const int64& EId, const TStr& attr) {
   // TODO(nkhadke): add error checking
   TInt64 vecType = KeyToIndexTypeE(attr).Val1;
@@ -1582,7 +1582,7 @@ int64 TNEANet::DelAttrN(const TStr& attr) {
       IntDefaultsN.DelKey(attr);
     }
   } else if (vecType == StrType) {
-    VecOfStrVecsN[KeyToIndexTypeN.GetDat(attr).Val2] = TVec<TStr, int64>();  
+    VecOfStrVecsN[KeyToIndexTypeN.GetDat(attr).Val2] = TVec<TStr, int64>();
     if (StrDefaultsN.IsKey(attr)) {
       StrDefaultsN.DelKey(attr);
     }
@@ -1619,7 +1619,7 @@ int64 TNEANet::DelAttrE(const TStr& attr) {
     VecOfStrVecsE[KeyToIndexTypeE.GetDat(attr).Val2] = TVec<TStr, int64>();
     if (StrDefaultsE.IsKey(attr)) {
       StrDefaultsE.DelKey(attr);
-    }  
+    }
   } else if (vecType == FltType) {
     VecOfFltVecsE[KeyToIndexTypeE.GetDat(attr).Val2] = TVec<TFlt, int64>();
     if (FltDefaultsE.IsKey(attr)) {
@@ -2058,7 +2058,7 @@ int64 TUndirNet::AddNode(const int64& NId, const TVecPool<TInt64, int64>& Pool, 
   } else {
     IAssertR(!IsNode(NId), TStr::Fmt("NodeId %s already exists", TInt64::GetStr(NId).CStr()));
     NewNId = NId;
-    MxNId = TMath::Mx(NewNId+1, MxNId()); 
+    MxNId = TMath::Mx(NewNId+1, MxNId());
   }
   TNode& Node = NodeH.AddDat(NewNId);
   Node.Id = NewNId;

--- a/snap-core/network.h
+++ b/snap-core/network.h
@@ -1861,13 +1861,13 @@ protected:
   /// Gets Int node attribute val.  If not a proper attr, return default.
   TInt64 GetIntAttrDefaultN(const TStr& attribute) const { return IntDefaultsN.IsKey(attribute) ? IntDefaultsN.GetDat(attribute) : (TInt64) TInt64::Mn; }
   /// Gets Str node attribute val.  If not a proper attr, return default.
-  TStr GetStrAttrDefaultN(const TStr& attribute) const { return StrDefaultsN.IsKey(attribute) ? StrDefaultsN.GetDat(attribute) : (TStr) TStr::GetNullStr(); }
+  TStr GetStrAttrDefaultN(const TStr& attribute) const { return StrDefaultsN.IsKey(attribute) ? StrDefaultsN.GetDat(attribute) : (TStr) TStr(); }
   /// Gets Flt node attribute val.  If not a proper attr, return default.
   TFlt GetFltAttrDefaultN(const TStr& attribute) const { return FltDefaultsN.IsKey(attribute) ? FltDefaultsN.GetDat(attribute) : (TFlt) TFlt::Mn; }
   /// Gets Int edge attribute val.  If not a proper attr, return default.
   TInt64 GetIntAttrDefaultE(const TStr& attribute) const { return IntDefaultsE.IsKey(attribute) ? IntDefaultsE.GetDat(attribute) : (TInt64) TInt64::Mn; }
   /// Gets Str edge attribute val.  If not a proper attr, return default.
-  TStr GetStrAttrDefaultE(const TStr& attribute) const { return StrDefaultsE.IsKey(attribute) ? StrDefaultsE.GetDat(attribute) : (TStr) TStr::GetNullStr(); }
+  TStr GetStrAttrDefaultE(const TStr& attribute) const { return StrDefaultsE.IsKey(attribute) ? StrDefaultsE.GetDat(attribute) : (TStr) TStr(); }
   /// Gets Flt edge attribute val.  If not a proper attr, return default.
   TFlt GetFltAttrDefaultE(const TStr& attribute) const { return FltDefaultsE.IsKey(attribute) ? FltDefaultsE.GetDat(attribute) : (TFlt) TFlt::Mn; }
 public:
@@ -2589,7 +2589,7 @@ public:
   /// Adds a new Int node attribute to the hashmap.
   int64 AddIntAttrN(const TStr& attr, TInt64 defaultValue=TInt64::Mn);
   /// Adds a new Str node attribute to the hashmap.
-  int64 AddStrAttrN(const TStr& attr, TStr defaultValue=TStr::GetNullStr());
+  int64 AddStrAttrN(const TStr& attr, TStr defaultValue=TStr());
   /// Adds a new Flt node attribute to the hashmap.
   int64 AddFltAttrN(const TStr& attr, TFlt defaultValue=TFlt::Mn);
   /// Adds a new IntV node attribute to the hashmap.
@@ -2598,7 +2598,7 @@ public:
   /// Adds a new Int edge attribute to the hashmap.
   int64 AddIntAttrE(const TStr& attr, TInt64 defaultValue=TInt64::Mn);
   /// Adds a new Str edge attribute to the hashmap.
-  int64 AddStrAttrE(const TStr& attr, TStr defaultValue=TStr::GetNullStr());
+  int64 AddStrAttrE(const TStr& attr, TStr defaultValue=TStr());
   /// Adds a new Flt edge attribute to the hashmap.
   int64 AddFltAttrE(const TStr& attr, TFlt defaultValue=TFlt::Mn);
   /// Adds a new IntV edge attribute to the hashmap.

--- a/snap-core/network.h
+++ b/snap-core/network.h
@@ -1648,6 +1648,11 @@ public:
     TNodeI& operator++ (int) { NodeHI++; return *this; }
     bool operator < (const TNodeI& NodeI) const { return NodeHI < NodeI.NodeHI; }
     bool operator == (const TNodeI& NodeI) const { return NodeHI == NodeI.NodeHI; }
+    /// Following functions are required for C++11 range loops
+    TNodeI& operator++ () { return operator++(0); }
+    bool operator != (const TNodeI& NodeI) const { return !(NodeI == *this); }
+    const TNodeI& operator*() const { return *this; }
+    TNodeI& operator*() { return *this; }
     /// Returns ID of the current node.
     int64 GetId() const { return NodeHI.GetDat().GetId(); }
     /// Returns degree of the current node, the sum of in-degree and out-degree.
@@ -1717,6 +1722,11 @@ public:
     TEdgeI& operator++ (int) { EdgeHI++; return *this; }
     bool operator < (const TEdgeI& EdgeI) const { return EdgeHI < EdgeI.EdgeHI; }
     bool operator == (const TEdgeI& EdgeI) const { return EdgeHI == EdgeI.EdgeHI; }
+    /// Following functions are required for C++11 range loops
+    TEdgeI& operator++ () { return operator++(0); }
+    bool operator != (const TEdgeI& EdgeI) const { return !(EdgeI == *this); }
+    const TEdgeI& operator*() const { return *this; }
+    TEdgeI& operator*() { return *this; }
     /// Returns edge ID.
     int64 GetId() const { return EdgeHI.GetDat().GetId(); }
     /// Returns the source of the edge.
@@ -1918,7 +1928,7 @@ private:
   };
 
 protected:
-  /// Return 1 if in Dense, 0 if in Sparse, -1 if neither 
+  /// Return 1 if in Dense, 0 if in Sparse, -1 if neither
   TInt CheckDenseOrSparseN(const TStr& attr) const {
     if (!KeyToDenseN.IsKey(attr)) return -1;
     if (KeyToDenseN.GetDat(attr)) return 1;
@@ -1930,7 +1940,7 @@ protected:
     if (KeyToDenseE.GetDat(attr)) return 1;
     return 0;
   }
-  
+
 
 public:
   TNEANet() : CRef(), MxNId(0), MxEId(0), NodeH(), EdgeH(),
@@ -1987,7 +1997,7 @@ public:
     VecOfStrVecsN.Save(SOut); VecOfStrVecsE.Save(SOut);
     VecOfFltVecsN.Save(SOut); VecOfFltVecsE.Save(SOut);
     VecOfIntVecVecsN.Save(SOut); VecOfIntVecVecsE.Save(SOut);
-    VecOfIntHashVecsN.Save(SOut); VecOfIntHashVecsE.Save(SOut); 
+    VecOfIntHashVecsN.Save(SOut); VecOfIntHashVecsE.Save(SOut);
     SAttrN.Save(SOut); SAttrE.Save(SOut); }
   /// Saves the graph to a (binary) stream SOut. Available for backwards compatibility.
   void Save_V1(TSOut& SOut) const {
@@ -2009,7 +2019,7 @@ public:
     VecOfIntVecsN.Save(SOut); VecOfIntVecsE.Save(SOut);
     VecOfStrVecsN.Save(SOut); VecOfStrVecsE.Save(SOut);
     VecOfFltVecsN.Save(SOut); VecOfFltVecsE.Save(SOut);
-    VecOfIntVecVecsN.Save(SOut); VecOfIntVecVecsE.Save(SOut); 
+    VecOfIntVecVecsN.Save(SOut); VecOfIntVecVecsE.Save(SOut);
     SAttrN.Save(SOut); SAttrE.Save(SOut); }
   /// Static cons returns pointer to graph. Ex: PNEANet Graph=TNEANet::New().
   static PNEANet New() { return PNEANet(new TNEANet()); }
@@ -2100,7 +2110,7 @@ public:
 
   /// Allows for run-time checking the type of the graph (see the TGraphFlag for flags).
   bool HasFlag(const TGraphFlag& Flag) const;
-  
+
   TNEANet& operator = (const TNEANet& Graph) { if (this!=&Graph) {
     MxNId=Graph.MxNId; MxEId=Graph.MxEId; NodeH=Graph.NodeH; EdgeH=Graph.EdgeH; }
     return *this; }
@@ -2125,6 +2135,8 @@ public:
   TNodeI EndNI() const { return TNodeI(NodeH.EndI(), this); }
   /// Returns an iterator referring to the node of ID NId in the graph.
   TNodeI GetNI(const int64& NId) const { return TNodeI(NodeH.GetI(NId), this); }
+  /// Returns wraper for C++ range-based loops over nodes
+  TIterNode<TNEANet> GetNI() const { return TIterNode<TNEANet>(this); }
   /// Returns an iterator referring to the first node's int attribute.
   TAIntI BegNAIntI(const TStr& attr) const {
     return TAIntI(VecOfIntVecsN[KeyToIndexTypeN.GetDat(attr).Val2].BegI(), attr, false, this); }
@@ -2419,6 +2431,8 @@ public:
   TEdgeI GetEI(const int64& EId) const { return TEdgeI(EdgeH.GetI(EId), this); }
   /// Returns an iterator referring to edge (SrcNId, DstNId) in the graph.
   TEdgeI GetEI(const int64& SrcNId, const int64& DstNId) const { return GetEI(GetEId(SrcNId, DstNId)); }
+  /// Returns wraper for C++ range-based loops over edges
+  TIterEdge<TNEANet> GetEI() const { return TIterEdge<TNEANet>(this); }
 
   /// Returns an ID of a random node in the graph.
   int64 GetRndNId(TRnd& Rnd=TInt::Rnd) { return NodeH.GetKey(NodeH.GetRndKeyId(Rnd, 0.8)); }
@@ -2440,7 +2454,7 @@ public:
     KeyToIndexTypeN.Clr(); KeyToIndexTypeE.Clr(); IntDefaultsN.Clr(); IntDefaultsE.Clr();
     StrDefaultsN.Clr(); StrDefaultsE.Clr(); FltDefaultsN.Clr(); FltDefaultsE.Clr();
     VecOfIntVecsN.Clr(); VecOfIntVecsE.Clr(); VecOfStrVecsN.Clr(); VecOfStrVecsE.Clr();
-    VecOfFltVecsN.Clr(); VecOfFltVecsE.Clr(); VecOfIntVecVecsN.Clr(); VecOfIntVecVecsE.Clr(); 
+    VecOfFltVecsN.Clr(); VecOfFltVecsE.Clr(); VecOfIntVecVecsN.Clr(); VecOfIntVecVecsE.Clr();
     SAttrN.Clr(); SAttrE.Clr();}
   /// Reserves memory for a graph of Nodes nodes and Edges edges.
   void Reserve(const int64& Nodes, const int64& Edges) {
@@ -2550,23 +2564,23 @@ public:
   TInt64 GetIntAttrIndDatE(const TEdgeI& EdgeI, const int64& index) { return GetIntAttrIndDatE(EdgeI.GetId(), index); }
   /// Gets the value of an int edge attr specified by edge ID \c EId and the attr \c index.
   TInt64 GetIntAttrIndDatE(const int64& EId, const int64& index);
- 
+
   /// Gets the value of a float edge attr specified by edge iterator \c EdgeI and the attr \c index.
   TFlt GetFltAttrIndDatE(const TEdgeI& EdgeI, const int& index) { return GetFltAttrIndDatE(EdgeI.GetId(), index); }
   /// Gets the value of an int edge attr specified by edge ID \c EId and the attr \c index.
   TFlt GetFltAttrIndDatE(const int64& EId, const int64& index);
- 
+
   /// Gets the value of a string edge attr specified by edge iterator \c EdgeI and the attr \c index.
   TStr GetStrAttrIndDatE(const TEdgeI& EdgeI, const int64& index) { return GetStrAttrIndDatE(EdgeI.GetId(), index); }
   /// Gets the value of an int edge attr specified by edge ID \c EId and the attr \c index.
   TStr GetStrAttrIndDatE(const int64& EId, const int64& index);
- 
+
   /// Deletes the node attribute for NodeI.
-  int64 DelAttrDatN(const TNodeI& NodeI, const TStr& attr) { return DelAttrDatN(NodeI.GetId(), attr); } 
-  int64 DelAttrDatN(const int64& NId, const TStr& attr); 
+  int64 DelAttrDatN(const TNodeI& NodeI, const TStr& attr) { return DelAttrDatN(NodeI.GetId(), attr); }
+  int64 DelAttrDatN(const int64& NId, const TStr& attr);
   /// Deletes the edge attribute for NodeI.
-  int64 DelAttrDatE(const TEdgeI& EdgeI, const TStr& attr) { return DelAttrDatE(EdgeI.GetId(), attr); } 
-  int64 DelAttrDatE(const int64& EId, const TStr& attr); 
+  int64 DelAttrDatE(const TEdgeI& EdgeI, const TStr& attr) { return DelAttrDatE(EdgeI.GetId(), attr); }
+  int64 DelAttrDatE(const int64& EId, const TStr& attr);
   /// Deletes attribute values for all nodes, including sparse attributes. Labels and defaults for dense attributes are preserved.
   int64 DelAllAttrDatN();
   /// Deletes attribute values for all edges, including sparse attributes. Labels and defaults for dense attributes are preserved.
@@ -2708,7 +2722,7 @@ public:
 
   /// Adds Str sparse attribute with name \c AttrName to the given node with id \c NId.
   int64 AddSAttrDatN(const TInt64& NId, const TStr& AttrName, const TStr& Val);
-  /// Adds Str sparse attribute with id \c AttrId to the given node with id \c NId. 
+  /// Adds Str sparse attribute with id \c AttrId to the given node with id \c NId.
   int64 AddSAttrDatN(const TInt64& NId, const TInt64& AttrId, const TStr& Val);
 
   /// Adds Str sparse attribute with name \c AttrName to \c NodeI.
@@ -2722,7 +2736,7 @@ public:
 
   /// Gets Int sparse attribute with name \c AttrName from node with id \c NId.
   int64 GetSAttrDatN(const TInt64& NId, const TStr& AttrName, TInt64& ValX) const;
-  /// Gets Int sparse attribute with id \c AttrId from node with id \c NId. 
+  /// Gets Int sparse attribute with id \c AttrId from node with id \c NId.
   int64 GetSAttrDatN(const TInt64& NId, const TInt64& AttrId, TInt64& ValX) const;
 
   /// Gets Int sparse attribute with name \c AttrName from \c NodeI.
@@ -2742,7 +2756,7 @@ public:
   /// Gets Flt sparse attribute with name \c AttrName from \c NodeI.
   int64 GetSAttrDatN(const TNodeI& NodeI, const TStr& AttrName, TFlt& ValX) const {
     return GetSAttrDatN(NodeI.GetId(), AttrName, ValX);
-  } 
+  }
   /// Gets Flt sparse attribute with id \c AttrId from \c NodeI.
   int64 GetSAttrDatN(const TNodeI& NodeI, const TInt64& AttrId, TFlt& ValX) const {
     return GetSAttrDatN(NodeI.GetId(), AttrId, ValX);
@@ -2798,7 +2812,7 @@ public:
 
   /// Adds Int sparse attribute with name \c AttrName to the given edge with id \c EId.
   int64 AddSAttrDatE(const TInt64& EId, const TStr& AttrName, const TInt64& Val);
-  /// Adds Int sparse attribute with id \c AttrId to the given edge with id \c EId. 
+  /// Adds Int sparse attribute with id \c AttrId to the given edge with id \c EId.
   int64 AddSAttrDatE(const TInt64& EId, const TInt64& AttrId, const TInt64& Val);
 
   /// Adds Int sparse attribute with name \c AttrName to \c EdgeI.
@@ -2850,10 +2864,10 @@ public:
   /// Gets Int sparse attribute with id \c AttrId from \c EdgeI.
   int64 GetSAttrDatE(const TEdgeI& EdgeI, const TInt64& AttrId, TInt64& ValX) const {
     return GetSAttrDatE(EdgeI.GetId(), AttrId, ValX);
-  } 
+  }
 
   /// Gets Flt sparse attribute with name \c AttrName from edge with id \c EId.
-  int64 GetSAttrDatE(const TInt64& EId, const TStr& AttrName, TFlt& ValX) const; 
+  int64 GetSAttrDatE(const TInt64& EId, const TStr& AttrName, TFlt& ValX) const;
   /// Gets Flt sparse attribute with id \c AttrId from edge with id \c EId.
   int64 GetSAttrDatE(const TInt64& EId, const TInt64& AttrId, TFlt& ValX) const;
 
@@ -2864,7 +2878,7 @@ public:
   /// Gets Flt sparse attribute with id \c AttrId from \c EdgeI.
   int64 GetSAttrDatE(const TEdgeI& EdgeI, const TInt64& AttrId, TFlt& ValX) const {
     return GetSAttrDatE(EdgeI.GetId(), AttrId, ValX);
-  } 
+  }
 
   /// Gets Str sparse attribute with name \c AttrName from edge with id \c EId.
   int64 GetSAttrDatE(const TInt64& EId, const TStr& AttrName, TStr& ValX) const;
@@ -2892,7 +2906,7 @@ public:
   /// Deletes sparse attribute with id \c AttrId from \c EdgeI.
   int64 DelSAttrDatE(const TEdgeI& EdgeI, const TInt64& AttrId) {
     return DelSAttrDatE(EdgeI.GetId(), AttrId);
-  } 
+  }
   /// Gets a list of all sparse attributes of type \c AttrType for edge with id \c EId.
   int64 GetSAttrVE(const TInt64& EId, const TAttrType AttrType, TAttrPrV& AttrV) const;
   /// Gets a list of all sparse attributes of type \c AttrType for \c EdgeI.
@@ -3103,7 +3117,7 @@ public:
   bool HasFlag(const TGraphFlag& Flag) const;
   TUndirNet& operator = (const TUndirNet& Graph) {
     if (this!=&Graph) { MxNId=Graph.MxNId; NEdges=Graph.NEdges; NodeH=Graph.NodeH; } return *this; }
-  
+
   /// Returns the number of nodes in the network.
   int64 GetNodes() const { return NodeH.Len(); }
   /// Adds a node of ID NId to the network. ##TUndirNet::AddNode
@@ -3208,7 +3222,7 @@ public:
 
   /// Adds Str sparse attribute with name \c AttrName to the given node with id \c NId.
   int64 AddSAttrDatN(const TInt64& NId, const TStr& AttrName, const TStr& Val);
-  /// Adds Str sparse attribute with id \c AttrId to the given node with id \c NId. 
+  /// Adds Str sparse attribute with id \c AttrId to the given node with id \c NId.
   int64 AddSAttrDatN(const TInt64& NId, const TInt64& AttrId, const TStr& Val);
 
   /// Adds Str sparse attribute with name \c AttrName to \c NodeI.
@@ -3222,7 +3236,7 @@ public:
 
   /// Gets Int sparse attribute with name \c AttrName from node with id \c NId.
   int64 GetSAttrDatN(const TInt64& NId, const TStr& AttrName, TInt64& ValX) const;
-  /// Gets Int sparse attribute with id \c AttrId from node with id \c NId. 
+  /// Gets Int sparse attribute with id \c AttrId from node with id \c NId.
   int64 GetSAttrDatN(const TInt64& NId, const TInt64& AttrId, TInt64& ValX) const;
 
   /// Gets Int sparse attribute with name \c AttrName from \c NodeI.
@@ -3242,7 +3256,7 @@ public:
   /// Gets Flt sparse attribute with name \c AttrName from \c NodeI.
   int64 GetSAttrDatN(const TNodeI& NodeI, const TStr& AttrName, TFlt& ValX) const {
     return GetSAttrDatN(NodeI.GetId(), AttrName, ValX);
-  } 
+  }
   /// Gets Flt sparse attribute with id \c AttrId from \c NodeI.
   int64 GetSAttrDatN(const TNodeI& NodeI, const TInt64& AttrId, TFlt& ValX) const {
     return GetSAttrDatN(NodeI.GetId(), AttrId, ValX);
@@ -3350,10 +3364,10 @@ public:
   /// Gets Int sparse attribute with id \c AttrId from \c EdgeI.
   int64 GetSAttrDatE(const TEdgeI& EdgeI, const TInt64& AttrId, TInt64& ValX) const {
     return GetSAttrDatE(EdgeI.GetSrcNId(), EdgeI.GetDstNId(), AttrId, ValX);
-  } 
+  }
 
   /// Gets Flt sparse attribute with name \c AttrName from edge with ids \c SrcId and \c DstId.
-  int64 GetSAttrDatE(const int64& SrcNId, const int64& DstNId, const TStr& AttrName, TFlt& ValX) const; 
+  int64 GetSAttrDatE(const int64& SrcNId, const int64& DstNId, const TStr& AttrName, TFlt& ValX) const;
   /// Gets Flt sparse attribute with id \c AttrId from edge with ids \c SrcId and \c DstId.
   int64 GetSAttrDatE(const int64& SrcNId, const int64& DstNId, const TInt64& AttrId, TFlt& ValX) const;
 
@@ -3364,7 +3378,7 @@ public:
   /// Gets Flt sparse attribute with id \c AttrId from \c EdgeI.
   int64 GetSAttrDatE(const TEdgeI& EdgeI, const TInt64& AttrId, TFlt& ValX) const {
     return GetSAttrDatE(EdgeI.GetSrcNId(), EdgeI.GetDstNId(), AttrId, ValX);
-  } 
+  }
 
   /// Gets Str sparse attribute with name \c AttrName from edge with ids \c SrcId and \c DstId.
   int64 GetSAttrDatE(const int64& SrcNId, const int64& DstNId, const TStr& AttrName, TStr& ValX) const;
@@ -3392,7 +3406,7 @@ public:
   /// Deletes sparse attribute with id \c AttrId from \c EdgeI.
   int64 DelSAttrDatE(const TEdgeI& EdgeI, const TInt64& AttrId) {
     return DelSAttrDatE(EdgeI.GetSrcNId(), EdgeI.GetDstNId(), AttrId);
-  } 
+  }
   /// Gets a list of all sparse attributes of type \c AttrType for edge with ids \c SrcId and \c DstId.
   int64 GetSAttrVE(const int64& SrcNId, const int64& DstNId, const TAttrType AttrType, TAttrPrV& AttrV) const;
   /// Gets a list of all sparse attributes of type \c AttrType for \c EdgeI.
@@ -3573,7 +3587,7 @@ public:
   bool HasFlag(const TGraphFlag& Flag) const;
   TDirNet& operator = (const TDirNet& Graph) {
     if (this!=&Graph) { MxNId=Graph.MxNId; NodeH=Graph.NodeH; }  return *this; }
-  
+
   /// Returns the number of nodes in the network.
   int64 GetNodes() const { return NodeH.Len(); }
   /// Adds a node of ID NId to the network. ##TDirNet::AddNode
@@ -3682,7 +3696,7 @@ public:
 
   /// Adds Str sparse attribute with name \c AttrName to the given node with id \c NId.
   int64 AddSAttrDatN(const TInt64& NId, const TStr& AttrName, const TStr& Val);
-  /// Adds Str sparse attribute with id \c AttrId to the given node with id \c NId. 
+  /// Adds Str sparse attribute with id \c AttrId to the given node with id \c NId.
   int64 AddSAttrDatN(const TInt64& NId, const TInt64& AttrId, const TStr& Val);
 
   /// Adds Str sparse attribute with name \c AttrName to \c NodeI.
@@ -3696,7 +3710,7 @@ public:
 
   /// Gets Int sparse attribute with name \c AttrName from node with id \c NId.
   int64 GetSAttrDatN(const TInt64& NId, const TStr& AttrName, TInt64& ValX) const;
-  /// Gets Int sparse attribute with id \c AttrId from node with id \c NId. 
+  /// Gets Int sparse attribute with id \c AttrId from node with id \c NId.
   int64 GetSAttrDatN(const TInt64& NId, const TInt64& AttrId, TInt64& ValX) const;
 
   /// Gets Int sparse attribute with name \c AttrName from \c NodeI.
@@ -3716,7 +3730,7 @@ public:
   /// Gets Flt sparse attribute with name \c AttrName from \c NodeI.
   int64 GetSAttrDatN(const TNodeI& NodeI, const TStr& AttrName, TFlt& ValX) const {
     return GetSAttrDatN(NodeI.GetId(), AttrName, ValX);
-  } 
+  }
   /// Gets Flt sparse attribute with id \c AttrId from \c NodeI.
   int64 GetSAttrDatN(const TNodeI& NodeI, const TInt64& AttrId, TFlt& ValX) const {
     return GetSAttrDatN(NodeI.GetId(), AttrId, ValX);
@@ -3824,10 +3838,10 @@ public:
   /// Gets Int sparse attribute with id \c AttrId from \c EdgeI.
   int64 GetSAttrDatE(const TEdgeI& EdgeI, const TInt64& AttrId, TInt64& ValX) const {
     return GetSAttrDatE(EdgeI.GetSrcNId(), EdgeI.GetDstNId(), AttrId, ValX);
-  } 
+  }
 
   /// Gets Flt sparse attribute with name \c AttrName from edge with ids \c SrcId and \c DstId.
-  int64 GetSAttrDatE(const int64& SrcNId, const int64& DstNId, const TStr& AttrName, TFlt& ValX) const; 
+  int64 GetSAttrDatE(const int64& SrcNId, const int64& DstNId, const TStr& AttrName, TFlt& ValX) const;
   /// Gets Flt sparse attribute with id \c AttrId from edge with ids \c SrcId and \c DstId.
   int64 GetSAttrDatE(const int64& SrcNId, const int64& DstNId, const TInt64& AttrId, TFlt& ValX) const;
 
@@ -3838,7 +3852,7 @@ public:
   /// Gets Flt sparse attribute with id \c AttrId from \c EdgeI.
   int64 GetSAttrDatE(const TEdgeI& EdgeI, const TInt64& AttrId, TFlt& ValX) const {
     return GetSAttrDatE(EdgeI.GetSrcNId(), EdgeI.GetDstNId(), AttrId, ValX);
-  } 
+  }
 
   /// Gets Str sparse attribute with name \c AttrName from edge with ids \c SrcId and \c DstId.
   int64 GetSAttrDatE(const int64& SrcNId, const int64& DstNId, const TStr& AttrName, TStr& ValX) const;
@@ -3866,7 +3880,7 @@ public:
   /// Deletes sparse attribute with id \c AttrId from \c EdgeI.
   int64 DelSAttrDatE(const TEdgeI& EdgeI, const TInt64& AttrId) {
     return DelSAttrDatE(EdgeI.GetSrcNId(), EdgeI.GetDstNId(), AttrId);
-  } 
+  }
   /// Gets a list of all sparse attributes of type \c AttrType for edge with ids \c SrcId and \c DstId.
   int64 GetSAttrVE(const int64& SrcNId, const int64& DstNId, const TAttrType AttrType, TAttrPrV& AttrV) const;
   /// Gets a list of all sparse attributes of type \c AttrType for \c EdgeI.

--- a/snap-core/networkmp.cpp
+++ b/snap-core/networkmp.cpp
@@ -143,7 +143,7 @@ TStr TNEANetMP::GetNodeAttrValue(const int64& NId, const TStrIntPr64H::TIter& No
     return (this->VecOfFltVecsN.GetVal(
       this->KeyToIndexTypeN.GetDat(NodeHI.GetKey()).Val2).GetVal(NodeH.GetKeyId(NId))).GetStr();
   }
-  return TStr::GetNullStr();
+  return TStr();
 }
 
 void TNEANetMP::AttrNameEI(const TInt64& EId, TStrIntPr64H::TIter EdgeHI, TStr64V& Names) const {
@@ -265,7 +265,7 @@ TStr TNEANetMP::GetEdgeAttrValue(const int64& EId, const TStrIntPr64H::TIter& Ed
     return (this->VecOfFltVecsE.GetVal(
       this->KeyToIndexTypeE.GetDat(EdgeHI.GetKey()).Val2).GetVal(EdgeH.GetKeyId(EId))).GetStr();
   }
-  return TStr::GetNullStr();
+  return TStr();
 }
 
 int64 TNEANetMP::AddNode(int64 NId) {
@@ -291,7 +291,7 @@ int64 TNEANetMP::AddNode(int64 NId) {
   }
   for (i = 0; i < VecOfStrVecsN.Len(); i++) {
     TVec<TStr, int64>& StrVec = VecOfStrVecsN[i];
-    StrVec.Ins(NodeH.GetKeyId(NId), TStr::GetNullStr());
+    StrVec.Ins(NodeH.GetKeyId(NId), TStr());
   }
   TVec<TStr, int64> DefStrVec = TVec<TStr, int64>();
   IntDefaultsN.GetKeyV(DefStrVec);
@@ -341,7 +341,7 @@ void TNEANetMP::AddNodeWithEdges(const TInt64& NId, TInt64V& InEIdV, TInt64V& Ou
 //    }
 //    for (i = 0; i < VecOfStrVecsE.Len(); i++) {
 //      TVec<TStr>& StrVec = VecOfStrVecsE[i];
-//      StrVec[EdgeH.GetKeyId(EId)] = TStr::GetNullStr();
+//      StrVec[EdgeH.GetKeyId(EId)] = TStr();
 //    }
 //    for (i = 0; i < VecOfFltVecsE.Len(); i++) {
 //      TVec<TFlt>& FltVec = VecOfFltVecsE[i];
@@ -361,7 +361,7 @@ void TNEANetMP::AddNodeWithEdges(const TInt64& NId, TInt64V& InEIdV, TInt64V& Ou
 //    }
 //    for (i = 0; i < VecOfStrVecsE.Len(); i++) {
 //      TVec<TStr>& StrVec = VecOfStrVecsE[i];
-//      StrVec[EdgeH.GetKeyId(EId)] = TStr::GetNullStr();
+//      StrVec[EdgeH.GetKeyId(EId)] = TStr();
 //    }
 //    for (i = 0; i < VecOfFltVecsE.Len(); i++) {
 //      TVec<TFlt>& FltVec = VecOfFltVecsE[i];
@@ -376,7 +376,7 @@ void TNEANetMP::AddNodeWithEdges(const TInt64& NId, TInt64V& InEIdV, TInt64V& Ou
 //  }
 //  for (i = 0; i < VecOfStrVecsN.Len(); i++) {
 //    TVec<TStr>& StrVec = VecOfStrVecsN[i];
-//    StrVec[NodeH.GetKeyId(NId)] = TStr::GetNullStr();
+//    StrVec[NodeH.GetKeyId(NId)] = TStr();
 //  }
 //  for (i = 0; i < VecOfFltVecsN.Len(); i++) {
 //    TVec<TFlt>& FltVec = VecOfFltVecsN[i];
@@ -411,7 +411,7 @@ int64 TNEANetMP::AddEdge(const int64& SrcNId, const int64& DstNId, int64 EId) {
 
   for (i = 0; i < VecOfStrVecsE.Len(); i++) {
     TVec<TStr, int64>& StrVec = VecOfStrVecsE[i];
-    StrVec.Ins(EdgeH.GetKeyId(EId), TStr::GetNullStr());
+    StrVec.Ins(EdgeH.GetKeyId(EId), TStr());
   }
   TVec<TStr, int64> DefStrVec = TVec<TStr, int64>();
   IntDefaultsE.GetKeyV(DefStrVec);
@@ -458,7 +458,7 @@ void TNEANetMP::AddEdgeUnchecked(const TInt64& EId, const int64 SrcNId, const in
 //  }
 //  for (i = 0; i < VecOfStrVecsE.Len(); i++) {
 //    TVec<TStr>& StrVec = VecOfStrVecsE[i];
-//    StrVec.Ins(EdgeH.GetKeyId(EId), TStr::GetNullStr());
+//    StrVec.Ins(EdgeH.GetKeyId(EId), TStr());
 //  }
 //  for (i = 0; i < VecOfFltVecsE.Len(); i++) {
 //    TVec<TFlt>& FltVec = VecOfFltVecsE[i];
@@ -597,7 +597,7 @@ void TNEANetMP::Dump(FILE *OutF) const {
     StrAttrValueNI(NodeI.GetId(), StrAttrN);
     fprintf(OutF, "    nas[%s]", TInt64::GetStr(StrAttrN.Len()).CStr());
     for (int64 i = 0; i < StrAttrN.Len(); i++) {
-      fprintf(OutF, " %*s", NodePlaces, StrAttrN[i]());
+      fprintf(OutF, " %*s", NodePlaces, StrAttrN[i].CStr());
     }
     TFlt64V FltAttrN;
     FltAttrValueNI(NodeI.GetId(), FltAttrN);
@@ -635,7 +635,7 @@ void TNEANetMP::Dump(FILE *OutF) const {
     StrAttrValueEI(EdgeI.GetId(), StrAttrE);
     fprintf(OutF, "    eas[%s]", TInt64::GetStr(StrAttrE.Len()).CStr());
     for (int64 i = 0; i < StrAttrE.Len(); i++) {
-      fprintf(OutF, " %*s", EdgePlaces, StrAttrE[i]());
+      fprintf(OutF, " %*s", EdgePlaces, StrAttrE[i].CStr());
     }
     TFlt64V FltAttrE;
     FltAttrValueEI(EdgeI.GetId(), FltAttrE);
@@ -688,7 +688,7 @@ int64 TNEANetMP::AddStrAttrDatN(const int64& NId, const TStr& value, const TStr&
     KeyToIndexTypeN.AddDat(attr, TInt64Pr(StrType, CurrLen));
     TVec<TStr, int64> NewVec = TVec<TStr, int64>();
     for (i = 0; i < MxNId; i++) {
-        NewVec.Ins(i, (TStr) TStr::GetNullStr() );
+        NewVec.Ins(i, (TStr) TStr() );
     }
     NewVec[NodeH.GetKeyId(NId)] = value;
     VecOfStrVecsN.Add(NewVec);
@@ -760,7 +760,7 @@ int64 TNEANetMP::AddStrAttrDatE(const int64& EId, const TStr& value, const TStr&
     KeyToIndexTypeE.AddDat(attr, TInt64Pr(StrType, CurrLen));
     TVec<TStr, int64> NewVec = TVec<TStr, int64>();
     for (i = 0; i < MxEId; i++) {
-      NewVec.Ins(i, (TStr) TStr::GetNullStr());
+      NewVec.Ins(i, (TStr) TStr());
     }
     NewVec[EdgeH.GetKeyId(EId)] = value;
     VecOfStrVecsE.Add(NewVec);

--- a/snap-core/networkmp.h
+++ b/snap-core/networkmp.h
@@ -232,13 +232,13 @@ private:
   /// Get Int node attribute val.  If not a proper attr, return default.
   TInt64 GetIntAttrDefaultN(const TStr& attribute) const { return IntDefaultsN.IsKey(attribute) ? IntDefaultsN.GetDat(attribute) : (TInt64) TInt64::Mn; }
   /// Get Str node attribute val.  If not a proper attr, return default.
-  TStr GetStrAttrDefaultN(const TStr& attribute) const { return StrDefaultsN.IsKey(attribute) ? StrDefaultsN.GetDat(attribute) : (TStr) TStr::GetNullStr(); }
+  TStr GetStrAttrDefaultN(const TStr& attribute) const { return StrDefaultsN.IsKey(attribute) ? StrDefaultsN.GetDat(attribute) : (TStr) TStr(); }
   /// Get Flt node attribute val.  If not a proper attr, return default.
   TFlt GetFltAttrDefaultN(const TStr& attribute) const { return FltDefaultsN.IsKey(attribute) ? FltDefaultsN.GetDat(attribute) : (TFlt) TFlt::Mn; }
   /// Get Int edge attribute val.  If not a proper attr, return default.
   TInt64 GetIntAttrDefaultE(const TStr& attribute) const { return IntDefaultsE.IsKey(attribute) ? IntDefaultsE.GetDat(attribute) : (TInt64) TInt64::Mn; }
   /// Get Str edge attribute val.  If not a proper attr, return default.
-  TStr GetStrAttrDefaultE(const TStr& attribute) const { return StrDefaultsE.IsKey(attribute) ? StrDefaultsE.GetDat(attribute) : (TStr) TStr::GetNullStr(); }
+  TStr GetStrAttrDefaultE(const TStr& attribute) const { return StrDefaultsE.IsKey(attribute) ? StrDefaultsE.GetDat(attribute) : (TStr) TStr(); }
   /// Get Flt edge attribute val.  If not a proper attr, return default.
   TFlt GetFltAttrDefaultE(const TStr& attribute) const { return FltDefaultsE.IsKey(attribute) ? FltDefaultsE.GetDat(attribute) : (TFlt) TFlt::Mn; }
 
@@ -601,14 +601,14 @@ public:
   /// Adds a new Int node attribute to the hashmap.
   int64 AddIntAttrN(const TStr& attr, TInt64 defaultValue=TInt::Mn);
   /// Adds a new Str node attribute to the hashmap.
-  int64 AddStrAttrN(const TStr& attr, TStr defaultValue=TStr::GetNullStr());
+  int64 AddStrAttrN(const TStr& attr, TStr defaultValue=TStr());
   /// Adds a new Flt node attribute to the hashmap.
   int64 AddFltAttrN(const TStr& attr, TFlt defaultValue=TFlt::Mn);
 
   /// Adds a new Int edge attribute to the hashmap.
   int64 AddIntAttrE(const TStr& attr, TInt64 defaultValue=TInt::Mn);
   /// Adds a new Str edge attribute to the hashmap.
-  int64 AddStrAttrE(const TStr& attr, TStr defaultValue=TStr::GetNullStr());
+  int64 AddStrAttrE(const TStr& attr, TStr defaultValue=TStr());
   /// Adds a new Flt edge attribute to the hashmap.
   int64 AddFltAttrE(const TStr& attr, TFlt defaultValue=TFlt::Mn);
 

--- a/snap-core/sim.cpp
+++ b/snap-core/sim.cpp
@@ -185,8 +185,7 @@ PNEANet KNNJaccard(PNGraph Graph, int K) {
 
   int sum_neighbors = 0;
   int ct;
-  int end;
-  end = Graph->GetNodes();
+  //int end = Graph->GetNodes();
   TIntV* Neighbors_old = new TIntV();
   TIntV* Neighbors = new TIntV();
   TIntV* temp;
@@ -263,4 +262,3 @@ PNEANet KNNJaccard(PNGraph Graph, int K) {
 
   return KNN;
 }
-

--- a/snap-core/table.cpp
+++ b/snap-core/table.cpp
@@ -212,6 +212,17 @@ TBool TRowIterator::CompareAtomicConstTStr(TInt64 ColIdx, const TStr& Val, TPred
   return Result;
 }
 
+TRowIteratorWrap::TRowIteratorWrap(TTable const* _Table): Table(_Table) { }
+
+TRowIterator TRowIteratorWrap::begin() {
+    return Table->BegRI();
+}
+
+TRowIterator TRowIteratorWrap::end() {
+    return Table->EndRI();
+}
+
+
 TRowIteratorWithRemove::TRowIteratorWithRemove(TInt64 RowIdx, TTable* TablePtr) :
   CurrRowIdx(RowIdx), Table(TablePtr), Start(RowIdx == TablePtr->FirstValidRow) {}
 
@@ -295,6 +306,16 @@ TBool TRowIteratorWithRemove::CompareAtomicConst(TInt64 ColIdx, const TPrimitive
       Result = TBool(false);
   }
   return Result;
+}
+
+TRowIteratorWithRemoveWrap::TRowIteratorWithRemoveWrap(TTable* _Table): Table(_Table) { }
+
+TRowIteratorWithRemove TRowIteratorWithRemoveWrap::begin() {
+    return Table->BegRIWR();
+}
+
+TRowIteratorWithRemove TRowIteratorWithRemoveWrap::end() {
+    return Table->EndRIWR();
 }
 
 // Better not use default constructor as it leads to a memory leak.

--- a/snap-core/table.cpp
+++ b/snap-core/table.cpp
@@ -780,8 +780,8 @@ PTable TTable::LoadSS(const Schema& S, const TStr& InFNm, TTableContext* Context
   if (GetMP() && NoStringCols) {
     // Right now, can load in parallel only in Linux (for mmap) and if
     // there are no string columns
-#ifdef GLib_LINUX
-     LoadSSPar(T, S, InFNm, RelevantCols, Separator, HasTitleLine);
+#ifdef GCC_ATOMIC
+    LoadSSPar(T, S, InFNm, RelevantCols, Separator, HasTitleLine);
 #else
     LoadSSSeq(T, S, InFNm, RelevantCols, Separator, HasTitleLine);
 #endif
@@ -1239,7 +1239,7 @@ void TTable::GroupByIntColMP(const TStr& GroupBy, THashMP<TInt64, TInt64V, int64
   GroupingSanityCheck(GroupBy, atInt);
   TIntPr64V Partitions;
   GetPartitionRanges(Partitions, 8*CHUNKS_PER_THREAD);
-  TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
+  //TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
   //double endPart = omp_get_wtime();
   //printf("Partition time = %f\n", endPart-startFn);
 
@@ -2901,7 +2901,7 @@ void TTable::SelectAtomicConst(const TStr& Col, const TPrimitive& Val, TPredComp
       //printf("Init time = %f\n", endInit-startFn);
       TIntPr64V Partitions;
       GetPartitionRanges(Partitions, omp_get_max_threads()*CHUNKS_PER_THREAD);
-      TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
+      //TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
       int64 RemoveCount = 0;
       //double endPart = omp_get_wtime();
       //printf("Partition time = %f\n", endPart-endInit);
@@ -4167,7 +4167,7 @@ void TTable::SetFltColToConstMP(TInt64 UpdateColIdx, TFlt DefaultFltVal){
     if(!GetMP()){ TExcept::Throw("Not Using MP!");}
   TIntPr64V Partitions;
   GetPartitionRanges(Partitions, omp_get_max_threads()*CHUNKS_PER_THREAD);
-  TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
+  //TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
   #pragma omp parallel for schedule(dynamic, CHUNKS_PER_THREAD)
   for (int64 i = 0; i < Partitions.Len(); i++){
     TRowIterator RowI(Partitions[i].GetVal1(), this);
@@ -4211,7 +4211,7 @@ void TTable::UpdateFltFromTableMP(const TStr& KeyAttr, const TStr& UpdateAttr,
 
   TIntPr64V Partitions;
   Table.GetPartitionRanges(Partitions, omp_get_max_threads()*CHUNKS_PER_THREAD);
-  TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
+  //TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
   TInt64V Locks(NumRows);
   Locks.PutAll(0);  // need to parallelize this...
 
@@ -4724,7 +4724,7 @@ void TTable::ColGenericOpMP(TInt64 ArgColIdx1, TInt64 ArgColIdx2, TAttrType ArgT
   if(ArgType1 == atInt && ArgType2 == atInt){ ResType = atInt;}
   TIntPr64V Partitions;
   GetPartitionRanges(Partitions, omp_get_max_threads()*CHUNKS_PER_THREAD);
-  TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
+  //TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
   #pragma omp parallel for schedule(dynamic, CHUNKS_PER_THREAD)
   for (int64 i = 0; i < Partitions.Len(); i++){
     TRowIterator RowI(Partitions[i].GetVal1(), this);
@@ -5046,7 +5046,7 @@ void TTable::ColGenericOp(const TStr& Attr1, const TFlt& Num, const TStr& ResAtt
 void TTable::ColGenericOpMP(const TInt64& ColIdx1, const TInt64& ColIdx2, TAttrType ArgType, const TFlt& Num, TArithOp op, TBool ShouldCast){
   TIntPr64V Partitions;
   GetPartitionRanges(Partitions, omp_get_max_threads()*CHUNKS_PER_THREAD);
-  TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
+  //TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
   #pragma omp parallel for schedule(dynamic, CHUNKS_PER_THREAD)
   for (int64 i = 0; i < Partitions.Len(); i++){
     TRowIterator RowI(Partitions[i].GetVal1(), this);

--- a/snap-core/table.cpp
+++ b/snap-core/table.cpp
@@ -1239,7 +1239,7 @@ void TTable::GroupByIntColMP(const TStr& GroupBy, THashMP<TInt64, TInt64V, int64
   GroupingSanityCheck(GroupBy, atInt);
   TIntPr64V Partitions;
   GetPartitionRanges(Partitions, 8*CHUNKS_PER_THREAD);
-  TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
+  //TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
   //double endPart = omp_get_wtime();
   //printf("Partition time = %f\n", endPart-startFn);
 
@@ -2901,7 +2901,7 @@ void TTable::SelectAtomicConst(const TStr& Col, const TPrimitive& Val, TPredComp
       //printf("Init time = %f\n", endInit-startFn);
       TIntPr64V Partitions;
       GetPartitionRanges(Partitions, omp_get_max_threads()*CHUNKS_PER_THREAD);
-      TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
+      //TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
       int64 RemoveCount = 0;
       //double endPart = omp_get_wtime();
       //printf("Partition time = %f\n", endPart-endInit);
@@ -4167,7 +4167,7 @@ void TTable::SetFltColToConstMP(TInt64 UpdateColIdx, TFlt DefaultFltVal){
     if(!GetMP()){ TExcept::Throw("Not Using MP!");}
   TIntPr64V Partitions;
   GetPartitionRanges(Partitions, omp_get_max_threads()*CHUNKS_PER_THREAD);
-  TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
+  //TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
   #pragma omp parallel for schedule(dynamic, CHUNKS_PER_THREAD)
   for (int64 i = 0; i < Partitions.Len(); i++){
     TRowIterator RowI(Partitions[i].GetVal1(), this);
@@ -4211,7 +4211,7 @@ void TTable::UpdateFltFromTableMP(const TStr& KeyAttr, const TStr& UpdateAttr,
 
   TIntPr64V Partitions;
   Table.GetPartitionRanges(Partitions, omp_get_max_threads()*CHUNKS_PER_THREAD);
-  TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
+  //TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
   TInt64V Locks(NumRows);
   Locks.PutAll(0);  // need to parallelize this...
 
@@ -4724,7 +4724,7 @@ void TTable::ColGenericOpMP(TInt64 ArgColIdx1, TInt64 ArgColIdx2, TAttrType ArgT
   if(ArgType1 == atInt && ArgType2 == atInt){ ResType = atInt;}
   TIntPr64V Partitions;
   GetPartitionRanges(Partitions, omp_get_max_threads()*CHUNKS_PER_THREAD);
-  TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
+  //TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
   #pragma omp parallel for schedule(dynamic, CHUNKS_PER_THREAD)
   for (int64 i = 0; i < Partitions.Len(); i++){
     TRowIterator RowI(Partitions[i].GetVal1(), this);
@@ -5046,7 +5046,7 @@ void TTable::ColGenericOp(const TStr& Attr1, const TFlt& Num, const TStr& ResAtt
 void TTable::ColGenericOpMP(const TInt64& ColIdx1, const TInt64& ColIdx2, TAttrType ArgType, const TFlt& Num, TArithOp op, TBool ShouldCast){
   TIntPr64V Partitions;
   GetPartitionRanges(Partitions, omp_get_max_threads()*CHUNKS_PER_THREAD);
-  TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
+  //TInt64 PartitionSize = Partitions[0].GetVal2()-Partitions[0].GetVal1()+1;
   #pragma omp parallel for schedule(dynamic, CHUNKS_PER_THREAD)
   for (int64 i = 0; i < Partitions.Len(); i++){
     TRowIterator RowI(Partitions[i].GetVal1(), this);

--- a/snap-core/table.cpp
+++ b/snap-core/table.cpp
@@ -922,7 +922,7 @@ void TTable::Dump(FILE *OutF) const {
       char C = (i == L-1) ? '\n' : '\t';
       switch (GetSchemaColType(i)) {
         case atInt: {
-          fprintf(OutF, "%s%c", TInt64::GetStr(RowI.GetIntAttr(GetSchemaColName(i)).Val).GetCStr(), C);
+          fprintf(OutF, "%s%c", TInt64::GetStr(RowI.GetIntAttr(GetSchemaColName(i)).Val).CStr(), C);
           break;
         }
         case atFlt: {

--- a/snap-core/table.h
+++ b/snap-core/table.h
@@ -350,12 +350,18 @@ public:
   TRowIterator(const TRowIterator& RowI): CurrRowIdx(RowI.CurrRowIdx), Table(RowI.Table) {}
   /// Increments the iterator.
   TRowIterator& operator++(int);
+  /// Increments the iterator (for C++11 range loops)
+  TRowIterator& operator++() { return operator++(0); }
   /// Increments the iterator (For Python compatibility).
   TRowIterator& Next();
   /// Checks if this iterator points to a row that is before the one pointed by \c RowI.
   bool operator < (const TRowIterator& RowI) const;
   /// Checks if this iterator points to the same row pointed by \c RowI.
   bool operator == (const TRowIterator& RowI) const;
+  /// Check if this iterator points to different row than pointed by \c RowI
+  bool operator != (const TRowIterator& RowI) const { return !(RowI == *this); }
+  /// Return iterator (for C++11 range loops)
+  const TRowIterator& operator*() const { return *this; }
   /// Gets the id of the row pointed by this iterator.
   TInt64 GetRowIdx() const;
   /// Returns value of integer attribute specified by integer column index for current row.
@@ -381,6 +387,17 @@ public:
 };
 
 //#//////////////////////////////////////////////
+/// C++11 iterator wrapper for rows
+class TRowIteratorWrap {
+  private:
+    TTable const* Table;
+  public:
+    TRowIteratorWrap(TTable const* _Table);
+    TRowIterator begin();
+    TRowIterator end();
+};
+
+//#//////////////////////////////////////////////
 /// Iterator class for TTable rows, that allows logical row removal while iterating.
 class TRowIteratorWithRemove {
   TInt64 CurrRowIdx; ///< Physical row index of current row pointer by iterator.
@@ -399,12 +416,18 @@ public:
     Table(RowI.Table), Start(RowI.Start) {}
   /// Increments the iterator.
   TRowIteratorWithRemove& operator++(int);
+  /// Increments the iterator (for C++11 range loops)
+  TRowIteratorWithRemove& operator++() { return operator++(0); }
   /// Increments the iterator (For Python compatibility).
   TRowIteratorWithRemove& Next();
   /// Checks if this iterator points to a row that is before the one pointed by \c RowI.
   bool operator < (const TRowIteratorWithRemove& RowI) const;
   /// Checks if this iterator points to the same row pointed by \c RowI.
   bool operator == (const TRowIteratorWithRemove& RowI) const;
+  /// Check if this iterator points to different row than pointed by \c RowI
+  bool operator != (const TRowIteratorWithRemove& RowI) const { return !(RowI == *this); }
+  /// Return iterator (for C++11 range loops)
+  const TRowIteratorWithRemove& operator*() const { return *this; }
   /// Gets physical index of current row.
   TInt64 GetRowIdx() const;
   /// Gets physical index of next row.
@@ -427,6 +450,17 @@ public:
   void RemoveNext();
   /// Compares value in column \c ColIdx with given primitive \c Val.
   TBool CompareAtomicConst(TInt64 ColIdx, const TPrimitive& Val, TPredComp Cmp);
+};
+
+//#//////////////////////////////////////////////
+/// C++11 iterator wrapper for rows
+class TRowIteratorWithRemoveWrap {
+  private:
+    TTable* Table;
+  public:
+    TRowIteratorWithRemoveWrap(TTable* _Table);
+    TRowIteratorWithRemove begin();
+    TRowIteratorWithRemove end();
 };
 
 //#//////////////////////////////////////////////
@@ -1147,10 +1181,14 @@ public:
   TRowIterator BegRI() const { return TRowIterator(FirstValidRow, this);}
   /// Gets iterator to the last valid row of the table.
   TRowIterator EndRI() const { return TRowIterator(TTable::Last, this);}
+  /// Get iterator wrapper for C++11 range loops
+  TRowIteratorWrap GetRI() const { return TRowIteratorWrap(this); }
   /// Gets iterator with reomve to the first valid row.
   TRowIteratorWithRemove BegRIWR(){ return TRowIteratorWithRemove(FirstValidRow, this);}
   /// Gets iterator with reomve to the last valid row.
   TRowIteratorWithRemove EndRIWR(){ return TRowIteratorWithRemove(TTable::Last, this);}
+  /// Get iterator wrapper for C++11 range loops
+  TRowIteratorWithRemoveWrap GetRIWR() { return TRowIteratorWithRemoveWrap(this); }
   /// Partitions the table into \c NumPartitions and populate \c Partitions with the ranges.
   void GetPartitionRanges(TIntPr64V& Partitions, TInt64 NumPartitions) const;
 

--- a/snap-core/util.cpp
+++ b/snap-core/util.cpp
@@ -629,18 +629,18 @@ TStr TStrUtil::GetStdName(TStr AuthorName) {
     pos++; }
   if (pos < AuthorName.Len()) {
     AuthorName = AuthorName.GetSubStr(0, pos-1).ToTrunc(); }
-  if (AuthorName.Empty()) { return TStr::GetNullStr(); }
+  if (AuthorName.Empty()) { return TStr(); }
 
   // replace everything after '('
   int b = AuthorName.SearchCh('(');
   if (b != -1) {
     AuthorName = AuthorName.GetSubStr(0, b-1).ToTrunc(); }
   // skip if contains ')'
-  if (AuthorName .SearchCh(')')!=-1) { return TStr::GetNullStr(); }
+  if (AuthorName .SearchCh(')')!=-1) { return TStr(); }
   // skip if it is not a name
   if (AuthorName .SearchStr("figures")!=-1 || AuthorName .SearchStr("macros")!=-1
    || AuthorName .SearchStr("univ")!=-1 || AuthorName .SearchStr("institute")!=-1) {
-    return TStr::GetNullStr();
+    return TStr();
   }
   // remove all non-letters (latex tags, ...)
   TChA NewName;
@@ -652,10 +652,10 @@ TStr TStrUtil::GetStdName(TStr AuthorName) {
   TStrV AuthNmV; StdName.SplitOnWs(AuthNmV);
   // too short -- not a name
   if (! AuthNmV.Empty() && AuthNmV.Last() == "jr") AuthNmV.DelLast();
-  if (AuthNmV.Len() < 2) return TStr::GetNullStr();
+  if (AuthNmV.Len() < 2) return TStr();
 
   const TStr LastNm = AuthNmV.Last();
-  if (! TCh::IsAlpha(LastNm[0]) || LastNm.Len() == 1) return TStr::GetNullStr();
+  if (! TCh::IsAlpha(LastNm[0]) || LastNm.Len() == 1) return TStr();
 
   IAssert(isalpha(AuthNmV[0][0]));
   return TStr::Fmt("%s_%c", LastNm.CStr(), AuthNmV[0][0]);
@@ -823,4 +823,3 @@ int WriteN(int fd, char *ptr, int nbytes) {
   return (nbytes-nleft);
 }
 #endif
-

--- a/snap-core/util.h
+++ b/snap-core/util.h
@@ -41,7 +41,7 @@ public:
   static TChA GetWebsiteNm(const TChA& UrlChA); // get website (GetDomNm2 or blog url)
   static bool GetNormalizedUrl(const TChA& UrlIn, const TChA& BaseUrl, TChA& UrlOut);
   static bool StripEnd(const TChA& Str, const TChA& SearchStr, TChA& NewStr);
-  
+
   static TChA GetShorStr(const TChA& LongStr, const int MaxLen=50);
   static TChA GetCleanStr(const TChA& ChA);
   static TChA GetCleanWrdStr(const TChA& ChA);
@@ -132,6 +132,30 @@ extern const char *ToCStr(const TInt i);
 extern const char *ToCStr(const TUInt i);
 extern const char *ToCStr(const TInt64 i);
 extern const char *ToCStr(const TUInt64 i);
+
+//#//////////////////////////////////////////////
+/// C++11 iterator wrapper for nodes
+template <class TGraph>
+class TIterNode {
+  private:
+    TGraph const* Graph;
+  public:
+    TIterNode(TGraph const* _Graph): Graph(_Graph) { }
+    class TGraph::TNodeI begin() { return Graph->BegNI(); }
+    class TGraph::TNodeI end() { return Graph->EndNI(); }
+};
+
+//#//////////////////////////////////////////////
+/// C++11 iterator wrapper for edges
+template <class TGraph>
+class TIterEdge {
+  private:
+    TGraph const* Graph;
+  public:
+    TIterEdge(TGraph const* _Graph): Graph(_Graph) { }
+    class TGraph::TEdgeI begin() { return Graph->BegEI(); }
+    class TGraph::TEdgeI end() { return Graph->EndEI(); }
+};
 
 //#//////////////////////////////////////////////
 /// Snapworld supporting functions

--- a/snap-exp/lsh.h
+++ b/snap-exp/lsh.h
@@ -11,10 +11,11 @@ private:
   private:
     TCRef CRef;
   public:
+    virtual ~HashFunc() { }
     virtual int Hash(TFltV Datum) = 0;
     friend class TPt<HashFunc>;
   };
-  
+
   class JaccardHash : public HashFunc {
   private:
     TIntV Perm;
@@ -32,7 +33,7 @@ private:
     CosineHash(TBoolV Hyperplane);
     int Hash(TFltV Datum);
   };
-  
+
   class EuclideanHash : public HashFunc {
   private:
     static const int Gap;

--- a/snap-exp/lsh.h
+++ b/snap-exp/lsh.h
@@ -11,7 +11,6 @@ private:
   private:
     TCRef CRef;
   public:
-    virtual ~HashFunc() { }
     virtual int Hash(TFltV Datum) = 0;
     virtual ~HashFunc() {};
     friend class TPt<HashFunc>;


### PR DESCRIPTION
Moved C++ version to C++11:
- added support for C++11 range loops to `TVec`, `THash`, `THashSet`, `TUNGraph`, `TNGraph`, `TNEGraph`, `TNEANet` and `TTable`.
- added move semantics to `TPair`, `TTriple`, `TVec`, `TVVec` and `THashKeyDat`
- replaced `TStr` with one not using smart pointers. Now `TStr` is thread safe when passing around.

Example for iteration over nodes and edges in `TUNGraph`:
```
for (const auto& NI : UNGraph->GetNI()) {
  // ...
}
for (const auto& EI : UNGraph->GetEI()) {
  // ...
}
```

More examples for iteration over these structures are located in `examples/iterators/iterators.cpp`